### PR TITLE
Improve game detection in core (bug 6020).

### DIFF
--- a/core/gamedll_bridge.cpp
+++ b/core/gamedll_bridge.cpp
@@ -37,21 +37,22 @@ class GameDllBridge : public IGameDllBridge
 public:
 	virtual bool DLLInit_Pre(const gamedll_bridge_info *info, char *buffer, size_t maxlength)
 	{
+		server = (IServerGameDLL *) info->isgd;
+		g_Metamod.SetGameDLLInfo((CreateInterfaceFn) info->gsFactory,
+			info->dllVersion,
+			true);
+		g_Metamod.SetVSPListener(info->vsp_listener_path);
+		mm_InitializeGlobals((CreateInterfaceFn) info->engineFactory,
+			(CreateInterfaceFn) info->physicsFactory,
+			(CreateInterfaceFn) info->fsFactory,
+			(CGlobalVars*) info->pGlobals);
+
 		if (!mm_DetectGameInformation())
 		{
 			UTIL_Format(buffer, maxlength, "Metamod:Source failed to detect game paths; cannot load.");
 			return false;
 		}
 
-		server = (IServerGameDLL *)info->isgd;
-		g_Metamod.SetGameDLLInfo((CreateInterfaceFn)info->gsFactory,
-								 info->dllVersion,
-								 true);
-		g_Metamod.SetVSPListener(info->vsp_listener_path);
-		mm_InitializeGlobals((CreateInterfaceFn)info->engineFactory,
-							 (CreateInterfaceFn)info->physicsFactory,
-							 (CreateInterfaceFn)info->fsFactory,
-							 (CGlobalVars*)info->pGlobals);
 		mm_InitializeForLoad();
 		mm_StartupMetamod(false);
 

--- a/core/metamod.cpp
+++ b/core/metamod.cpp
@@ -186,23 +186,11 @@ mm_DetectGameInformation()
 {
 	char game_path[PATH_SIZE];
 
-	/* Get value of -game from command line, defaulting to hl2 as engine seems to do */
-	const char *game_dir = provider->GetCommandLineValue("-game");
-
-	if (game_dir)
-	{
-		/* Get absolute path */
-		abspath(game_path, game_dir);
-	}
-	else
-	{
-		/* Get absolute path for current directory */
-		abspath(game_path, ".");
-	}
+	provider->GetGamePath(game_path, sizeof(game_path));
 
 	mod_path.assign(game_path);
 
-	engine_build = provider->DetermineSourceEngine(game_dir);
+	engine_build = provider->DetermineSourceEngine();
 
 	return true;
 }

--- a/core/metamod_provider.h
+++ b/core/metamod_provider.h
@@ -214,6 +214,14 @@ namespace SourceMM
 		virtual void SetConVarString(ConVar *convar, const char *str) =0;
 
 		/**
+		 * @brief Retrieves the absolute path to the game directory.
+		 *
+		 * @param buffer			Buffer in which to store path.
+		 * @param maxlen			Maximum length of buffer.
+		 */
+		virtual void GetGamePath(char *buffer, int maxlen) = 0;
+
+		/**
 		 * @brief Retrieves the game description.
 		 *
 		 * @return					Game description.
@@ -279,10 +287,9 @@ namespace SourceMM
 		/**
 		 * @brief Returns the Source Engine build.
 		 *
-		 * @param game			Game folder.
 		 * @return				SOURCE_ENGINE constant.
 		 */
-		virtual int DetermineSourceEngine(const char *game) =0;
+		virtual int DetermineSourceEngine() =0;
 
 		/**
 		 * @brief Processes a VDF plugin file.

--- a/core/provider/provider_ep2.cpp
+++ b/core/provider/provider_ep2.cpp
@@ -364,12 +364,17 @@ const char *BaseProvider::GetUserMessage(int index, int *size)
 	return usermsgs_list[index].name.c_str();
 }
 
+void BaseProvider::GetGamePath(char *pszBuffer, int len)
+{
+	engine->GetGameDir(pszBuffer, len);
+}
+
 const char *BaseProvider::GetGameDescription()
 {
 	return server->GetGameDescription();
 }
 
-int BaseProvider::DetermineSourceEngine(const char *game)
+int BaseProvider::DetermineSourceEngine()
 {
 #if SOURCE_ENGINE == SE_BLOODYGOODTIME
 	return SOURCE_ENGINE_BLOODYGOODTIME;

--- a/core/provider/provider_ep2.h
+++ b/core/provider/provider_ep2.h
@@ -66,6 +66,7 @@ public:
 		int flags);
 	virtual const char *GetConVarString(ConVar *convar);
 	virtual void SetConVarString(ConVar *convar, const char *str);
+	virtual void GetGamePath(char *pszBuffer, int len);
 	virtual const char *GetGameDescription();
 	virtual IConCommandBaseAccessor *GetConCommandBaseAccessor();
 	virtual bool RegisterConCommandBase(ConCommandBase *pCommand);
@@ -74,7 +75,7 @@ public:
 	virtual int GetUserMessageCount();
 	virtual int FindUserMessage(const char *name, int *size=NULL);
 	virtual const char *GetUserMessage(int index, int *size=NULL);
-	virtual int DetermineSourceEngine(const char *game);
+	virtual int DetermineSourceEngine();
 	virtual bool ProcessVDF(const char *file, char path[], size_t path_len, char alias[], size_t alias_len);
 };
 

--- a/core/vsp_bridge.cpp
+++ b/core/vsp_bridge.cpp
@@ -115,17 +115,18 @@ public:
 					break;
 			}
 
+			mm_InitializeGlobals((CreateInterfaceFn) info->engineFactory,
+				(CreateInterfaceFn) info->engineFactory,
+				(CreateInterfaceFn) info->engineFactory,
+				pGlobals);
+
 			if (!mm_DetectGameInformation())
 			{
 				UTIL_Format(error, maxlength, "Metamod:Source failed to detect game paths; cannot load.");
 				return false;
 			}
 
-			mm_InitializeForLoad();
-			mm_InitializeGlobals((CreateInterfaceFn)info->engineFactory,
-				(CreateInterfaceFn)info->engineFactory,
-				(CreateInterfaceFn)info->engineFactory,
-				pGlobals);
+			mm_InitializeForLoad();			
 			g_Metamod.NotifyVSPListening(info->vsp_callbacks, info->vsp_version);
 			mm_StartupMetamod(true);
 		}


### PR DESCRIPTION
See bug 6020 for background, https://bugs.alliedmods.net/show_bug.cgi?id=6020

This commit slightly reorders MM:S initialization logic so that the engine ptr is available in the provider before mm_DetectGameInformation is called. This allows us to just use engine->GetGameDir to get the absolute path to the game directory, rather than hoping -game is specified and calculating absolute path from there.

Tested on CS:GO with VSP loading, Dota 2 with GameDLL loading, and Dark Messiah (our old case for the "." fallback) with VSP loading.
