### PR TITLE
Fix broken Alien Swarm engine detection (regression from 013c5490904).

### DIFF
--- a/loader/loader.cpp
+++ b/loader/loader.cpp
@@ -288,19 +288,19 @@ mm_DetermineBackend(QueryValveInterface engineFactory, QueryValveInterface serve
 	else if (engineFactory("VEngineServer022", NULL) != NULL &&
 		engineFactory("VEngineCvar007", NULL) != NULL)
 	{
-		if (serverFactory("ServerGameClients004", NULL))
+		if (engineFactory("EngineTraceServer004", NULL) != NULL)
 		{
+			if (engineFactory("XboxSystemInterface001", NULL) != NULL)
+			{
+				return MMBackend_AlienSwarm;
+			}
+			
 			if (strcmp(game_name, "portal2") == 0)
 			{
 				return MMBackend_Portal2;
 			}
 
 			return MMBackend_Blade;
-		}
-
-		if (engineFactory("EngineTraceServer004", NULL) != NULL)
-		{
-			return MMBackend_AlienSwarm;
 		}
 		else if (engineFactory("VPrecacheSystem001", NULL) != NULL)
 		{


### PR DESCRIPTION
As mentioned in a recent [forum thread](https://forums.alliedmods.net/showthread.php?t=245637), Alien Swarm detection is broken in MM:S.

This turns out to be a regression from commit 013c549090445893a2.

The logic from that commit causes it to be detected as Blade Symphony because both ServerGameClients003 and ServerGameClients004 are both available in all of BS, Portal 2, and Swarm. (same for EngineTraceServer004).

This changes the Swarm check to look for XboxSystemInterface001. (The other two games have only 002)
