### PR TITLE
Relocate META_IFACE enum and utilize it more.

### DIFF
--- a/core-legacy/CSmmAPI.cpp
+++ b/core-legacy/CSmmAPI.cpp
@@ -186,13 +186,13 @@ void *CSmmAPI::MetaFactory(const char *iface, int *_ret, PluginId *id)
 	{
 		if (_ret)
 		{
-			*_ret = IFACE_OK;
+			*_ret = META_IFACE_OK;
 		}
 		return static_cast<void *>(static_cast<SourceHook::ISourceHook *>(&g_SourceHook));
 	} else if (strcmp(iface, MMIFACE_PLMANAGER) == 0) {
 		if (_ret)
 		{
-			*_ret = IFACE_OK;
+			*_ret = META_IFACE_OK;
 		}
 		return static_cast<void *>(static_cast<ISmmPluginManager *>(&g_PluginMngr));
 	}
@@ -209,7 +209,7 @@ void *CSmmAPI::MetaFactory(const char *iface, int *_ret, PluginId *id)
 		for (event=pl->m_Events.begin(); event!=pl->m_Events.end(); event++)
 		{
 			api = (*event).event;
-			ret = IFACE_FAILED;
+			ret = META_IFACE_FAILED;
 			if ( (val=api->OnMetamodQuery(iface, &ret)) != NULL )
 			{
 				if (_ret)
@@ -222,7 +222,7 @@ void *CSmmAPI::MetaFactory(const char *iface, int *_ret, PluginId *id)
 	}
 
 	if (_ret)
-		*_ret = IFACE_FAILED;
+		*_ret = META_IFACE_FAILED;
 
 	return NULL;
 }
@@ -371,7 +371,7 @@ void *CSmmAPI::InterfaceSearch(CreateInterfaceFn fn, const char *iface, int max,
 	{
 		if (ret)
 		{
-			*ret = IFACE_FAILED;
+			*ret = META_IFACE_FAILED;
 		}
 		return NULL;
 	}

--- a/core-legacy/ISmmPlugin.h
+++ b/core-legacy/ISmmPlugin.h
@@ -208,7 +208,7 @@ public:
 	 * @brief Called when engineFactory() is used through Metamod:Source's wrapper.
 	 * This can be used to provide interfaces to other plugins or the GameDLL.
 	 *
-	 * If ret is passed, you should fill it with IFACE_OK or IFACE_FAILED.
+	 * If ret is passed, you should fill it with META_IFACE_OK or META_IFACE_FAILED.
 	 *
 	 * @param iface			Interface string.
 	 * @param ret			Optional pointer to store return code.
@@ -218,7 +218,7 @@ public:
 	{
 		if (ret)
 		{
-			*ret = IFACE_FAILED;
+			*ret = META_IFACE_FAILED;
 		}
 
 		return NULL; 
@@ -228,7 +228,7 @@ public:
 	 * @brief Called when the physics factory is used through Metamod:Source's wrapper.
 	 * This can be used to provide interfaces to other plugins.
 	 *
-	 * If ret is passed, you should fill it with IFACE_OK or IFACE_FAILED.
+	 * If ret is passed, you should fill it with META_IFACE_OK or META_IFACE_FAILED.
 	 *
 	 * @param iface			Interface string.
 	 * @param ret			Optional pointer to store return code.
@@ -238,7 +238,7 @@ public:
 	{
 		if (ret)
 		{
-			*ret = IFACE_FAILED;
+			*ret = META_IFACE_FAILED;
 		}
 
 		return NULL; 
@@ -248,7 +248,7 @@ public:
 	 * @brief Called when the filesystem factory is used through Metamod:Source's wrapper.
 	 * This can be used to provide interfaces to other plugins.
 	 *
-	 * If ret is passed, you should fill it with IFACE_OK or IFACE_FAILED.
+	 * If ret is passed, you should fill it with META_IFACE_OK or META_IFACE_FAILED.
 	 *
 	 * @param iface			Interface string.
 	 * @param ret			Optional pointer to store return code.
@@ -258,7 +258,7 @@ public:
 	{
 		if (ret)
 		{
-			*ret = IFACE_FAILED;
+			*ret = META_IFACE_FAILED;
 		}
 		
 		return NULL; 
@@ -268,7 +268,7 @@ public:
 	 * @brief Called when the server DLL's factory is used through Metamod:Source's wrapper.
 	 * This can be used to provide interfaces to other plugins.
 	 *
-	 * If ret is passed, you should fill it with IFACE_OK or IFACE_FAILED.
+	 * If ret is passed, you should fill it with META_IFACE_OK or META_IFACE_FAILED.
 	 *
 	 * @param iface			Interface string.
 	 * @param ret			Optional pointer to store return code.
@@ -278,7 +278,7 @@ public:
 	{
 		if (ret)
 		{
-			*ret = IFACE_FAILED;
+			*ret = META_IFACE_FAILED;
 		}
 
 		return NULL; 
@@ -288,7 +288,7 @@ public:
 	 * @brief Called when Metamod's own factory is invoked.  
 	 * This can be used to provide interfaces to other plugins.
 	 *
-	 * If ret is passed, you should fill it with IFACE_OK or IFACE_FAILED.
+	 * If ret is passed, you should fill it with META_IFACE_OK or META_IFACE_FAILED.
 	 *
 	 * @param iface			Interface string.
 	 * @param ret			Optional pointer to store return code.
@@ -298,7 +298,7 @@ public:
 	{
 		if (ret)
 		{
-			*ret = IFACE_FAILED;
+			*ret = META_IFACE_FAILED;
 		}
 
 		return NULL; 	

--- a/core-legacy/ISmmPlugin.h
+++ b/core-legacy/ISmmPlugin.h
@@ -25,6 +25,13 @@
 
 class ISmmAPI;
 
+// Interface return status, binary-compatible with HL2SDK's IFACE_OK and IFACE_FAILED.
+enum 
+{
+	META_IFACE_OK = 0,
+	META_IFACE_FAILED
+};
+
 class ISmmPlugin
 {
 public:

--- a/core-legacy/gamedll_bridge.cpp
+++ b/core-legacy/gamedll_bridge.cpp
@@ -42,7 +42,7 @@ using namespace SourceMM;
 		pl = (*iter); \
 		for (event=pl->m_Events.begin(); event!=pl->m_Events.end(); event++) { \
 			api = (*event).event; \
-			mret = IFACE_FAILED; \
+			mret = META_IFACE_FAILED; \
 			if ( (val=api->On##nam##Query(iface, &mret)) != NULL ) { \
 				if (ret) *ret = mret; \
 				return val; \

--- a/core/ISmmPlugin.h
+++ b/core/ISmmPlugin.h
@@ -39,6 +39,13 @@
 #include <ISmmAPI.h>
 #include <ISmmPluginExt.h>
 
+// Interface return status, binary-compatible with HL2SDK's IFACE_OK and IFACE_FAILED.
+enum 
+{
+	META_IFACE_OK = 0,
+	META_IFACE_FAILED
+};
+
 namespace SourceMM
 {
 	class ISmmAPI;

--- a/core/ISmmPluginExt.h
+++ b/core/ISmmPluginExt.h
@@ -28,13 +28,6 @@
 
 #include <stddef.h>
 
-// Interface return status, binary-compatible with HL2SDK's IFACE_OK and IFACE_FAILED.
-enum 
-{
-	META_IFACE_OK = 0,
-	META_IFACE_FAILED
-};
-
 /**
  * @file ISmmPluginExt.h Provides an alternate method for loading plugins, 
  * without needing to include the default headers and all their Half-Life baggage.

--- a/core/metamod.cpp
+++ b/core/metamod.cpp
@@ -122,7 +122,7 @@ SourceMM::ISmmAPI *g_pMetamod = &g_Metamod;
 		pl = (*iter); \
 		for (event=pl->m_Events.begin(); event!=pl->m_Events.end(); event++) { \
 			api = (*event); \
-			mret = IFACE_FAILED; \
+			mret = META_IFACE_FAILED; \
 			if ( (val=api->On##nam##Query(iface, &mret)) != NULL ) { \
 				if (ret) *ret = mret; \
 				return val; \
@@ -688,7 +688,7 @@ void *MetamodSource::InterfaceSearch(CreateInterfaceFn fn, const char *iface, in
 	{
 		if (ret)
 		{
-			*ret = IFACE_FAILED;
+			*ret = META_IFACE_FAILED;
 		}
 		return NULL;
 	}
@@ -841,7 +841,7 @@ void *MetamodSource::MetaFactory(const char *iface, int *ret, PluginId *id)
 	{
 		if (ret)
 		{
-			*ret = IFACE_OK;
+			*ret = META_IFACE_OK;
 		}
 		return static_cast<void *>(static_cast<SourceHook::ISourceHook *>(&g_SourceHook));
 	}
@@ -849,7 +849,7 @@ void *MetamodSource::MetaFactory(const char *iface, int *ret, PluginId *id)
 	{
 		if (ret)
 		{
-			*ret = IFACE_OK;
+			*ret = META_IFACE_OK;
 		}
 		return static_cast<void *>(static_cast<ISmmPluginManager *>(&g_PluginMngr));
 	}
@@ -857,7 +857,7 @@ void *MetamodSource::MetaFactory(const char *iface, int *ret, PluginId *id)
 	{
 		if (ret)
 		{
-			*ret = IFACE_OK;
+			*ret = META_IFACE_OK;
 		}
 		return static_cast<void *>(static_cast<SourceHook::IHookManagerAutoGen *>(&g_SH_HookManagerAutoGen));
 	}
@@ -876,7 +876,7 @@ void *MetamodSource::MetaFactory(const char *iface, int *ret, PluginId *id)
 		for (event = pl->m_Events.begin(); event != pl->m_Events.end(); event++)
 		{
 			api = (*event);
-			subret = IFACE_FAILED;
+			subret = META_IFACE_FAILED;
 			if ((value = api->OnMetamodQuery(iface, &subret)) != NULL)
 			{
 				if (ret)
@@ -894,7 +894,7 @@ void *MetamodSource::MetaFactory(const char *iface, int *ret, PluginId *id)
 
 	if (ret)
 	{
-		*ret = IFACE_FAILED;
+		*ret = META_IFACE_FAILED;
 	}
 
 	return NULL;


### PR DESCRIPTION
This is for https://github.com/alliedmodders/sourcemod/pull/129 , which is for supporting engine independent extensions in SourceMod and other products that interface with MetaMod:Source.