### PR TITLE
Fix unused local typedefs warnings in SourceHook on GCC.

### DIFF
--- a/AMBuildScript
+++ b/AMBuildScript
@@ -131,6 +131,7 @@ class MMSConfig(object):
         '-msse',
         '-m32',
       ]
+      cfg.cxxflags += [ '-std=c++11' ]
       if (cxx.name == 'gcc' and cxx.majorVersion >= 4) or cxx.name == 'clang':
         cfg.cflags += ['-fvisibility=hidden']
         cfg.cxxflags += ['-fvisibility-inlines-hidden']

--- a/core/sourcehook/FastDelegate.h
+++ b/core/sourcehook/FastDelegate.h
@@ -178,8 +178,8 @@ inline OutputClass horrible_cast(const InputClass input){
 	// Cause a compile-time error if in, out and u are not the same size.
 	// If the compile fails here, it means the compiler has peculiar
 	// unions which would prevent the cast from working.
-	typedef int ERROR_CantUseHorrible_cast[sizeof(InputClass)==sizeof(u)
-		&& sizeof(InputClass)==sizeof(OutputClass) ? 1 : -1];
+	static_assert(sizeof(InputClass)==sizeof(u) && sizeof(InputClass)==sizeof(OutputClass),
+			"Can't use horrible cast");
 	u.in = input;
 	return u.out;
 }
@@ -294,8 +294,7 @@ struct SimplifyMemFunc {
 	inline static GenericClass *Convert(X *pthis, XFuncType function_to_bind,
 		GenericMemFuncType &bound_func) {
 		// Unsupported member function type -- force a compile failure.
-	    // (it's illegal to have a array with negative size).
-		typedef char ERROR_Unsupported_member_function_pointer_on_this_compiler[N-100];
+		static_assert(N >= 100, "Unsupported memeber function pointer on this compiler");
 		return 0;
 	}
 };
@@ -352,7 +351,7 @@ struct SimplifyMemFunc< SINGLE_MEMFUNCPTR_SIZE + sizeof(int) >  {
 			}s;
         } u;
 		// Check that the horrible_cast will work
-		typedef int ERROR_CantUsehorrible_cast[sizeof(function_to_bind)==sizeof(u.s)? 1 : -1];
+		static_assert(sizeof(function_to_bind)==sizeof(u.s), "Can't use horrible cast");
         u.func = function_to_bind;
 		bound_func = u.s.funcaddress;
 		return reinterpret_cast<GenericClass *>(reinterpret_cast<char *>(pthis) + u.s.delta);
@@ -409,9 +408,10 @@ struct SimplifyMemFunc<SINGLE_MEMFUNCPTR_SIZE + 2*sizeof(int) >
 			MicrosoftVirtualMFP s;
 		} u2;
 		// Check that the horrible_cast<>s will work
-		typedef int ERROR_CantUsehorrible_cast[sizeof(function_to_bind)==sizeof(u.s)
+		static_assert(sizeof(function_to_bind)==sizeof(u.s)
 			&& sizeof(function_to_bind)==sizeof(u.ProbeFunc)
-			&& sizeof(u2.virtfunc)==sizeof(u2.s) ? 1 : -1];
+			&& sizeof(u2.virtfunc)==sizeof(u2.s),
+			"Can't use horrible cast.");
    // Unfortunately, taking the address of a MF prevents it from being inlined, so
    // this next line can't be completely optimised away by the compiler.
 		u2.virtfunc = &GenericVirtualClass::GetThis;
@@ -455,7 +455,7 @@ struct SimplifyMemFunc<SINGLE_MEMFUNCPTR_SIZE + 3*sizeof(int) >
 		// We can generate correct code in this case. To prevent an incorrect call from
 		// ever being made, on MSVC6 we generate a warning, and call a function to
 		// make the program crash instantly.
-		typedef char ERROR_VC6CompilerBug[-100];
+		static_assert(true, "VC6 Compiler Bug");
 		return 0;
 	}
 };
@@ -487,7 +487,7 @@ struct SimplifyMemFunc<SINGLE_MEMFUNCPTR_SIZE + 3*sizeof(int) >
 			} s;
 		} u;
 		// Check that the horrible_cast will work
-		typedef int ERROR_CantUsehorrible_cast[sizeof(XFuncType)==sizeof(u.s)? 1 : -1];
+		static_assert(sizeof(XFuncType)==sizeof(u.s), "Can't use horrible cast.");
 		u.func = function_to_bind;
 		bound_func = u.s.funcaddress;
 		int virtual_delta = 0;
@@ -781,7 +781,7 @@ public:
 		// Ensure that there's a compilation failure if function pointers
 		// and data pointers have different sizes.
 		// If you get this error, you need to #undef FASTDELEGATE_USESTATICFUNCTIONHACK.
-		typedef int ERROR_CantUseEvilMethod[sizeof(GenericClass *)==sizeof(function_to_bind) ? 1 : -1];
+		static_assert(sizeof(GenericClass *)==sizeof(function_to_bind), "Can't use evil method.");
 		m_pthis = horrible_cast<GenericClass *>(function_to_bind);
 		// MSVC, SunC++ and DMC accept the following (non-standard) code:
 //		m_pthis = static_cast<GenericClass *>(static_cast<void *>(function_to_bind));
@@ -796,7 +796,7 @@ public:
 		// Ensure that there's a compilation failure if function pointers
 		// and data pointers have different sizes.
 		// If you get this error, you need to #undef FASTDELEGATE_USESTATICFUNCTIONHACK.
-		typedef int ERROR_CantUseEvilMethod[sizeof(UnvoidStaticFuncPtr)==sizeof(this) ? 1 : -1];
+		static_assert(sizeof(UnvoidStaticFuncPtr)==sizeof(this), "Can't use evil method.");
 		return horrible_cast<UnvoidStaticFuncPtr>(this);
 	}
 #endif // !defined(FASTDELEGATE_USESTATICFUNCTIONHACK)


### PR DESCRIPTION
As reported here, https://forums.alliedmods.net/showthread.php?t=222613, the compile-time checks in FastDelegate.h are triggering warnings on newer compilers. With our default to treat warnings as errors, this causes a problem when compiling MM:S, MM:S plugins, or anything else that includes SourceHook.

I propose that we change these to use static_assert (thus requiring C++11 support).