### PR TITLE
Shim for TF2-branch games to find latest, non-shimmed engine iface.

### DIFF
--- a/core/provider/provider_ep2.cpp
+++ b/core/provider/provider_ep2.cpp
@@ -108,7 +108,16 @@ void BaseProvider::ConsolePrint(const char *str)
 void BaseProvider::Notify_DLLInit_Pre(CreateInterfaceFn engineFactory, 
 									  CreateInterfaceFn serverFactory)
 {
+#if SOURCE_ENGINE == SE_TF2 || SOURCE_ENGINE == SE_CSS || SOURCE_ENGINE == SE_DODS || SOURCE_ENGINE == SE_HL2DM || SOURCE_ENGINE == SE_SDK2013
+	// Shim to avoid hooking shims
+	engine = (IVEngineServer *)((engineFactory)("VEngineServer023", NULL));
+	if (!engine)
+	{
+		engine = (IVEngineServer *)((engineFactory)("VEngineServer022", NULL));
+	}
+#else
 	engine = (IVEngineServer *)((engineFactory)(INTERFACEVERSION_VENGINESERVER, NULL));
+#endif
 	if (!engine)
 	{
 		DisplayError("Could not find IVEngineServer! Metamod cannot load.");


### PR DESCRIPTION
This gross slab of hackeroni ensures that we get the latest (for now) engine iface available on TF2-branch games (including CS:S, DoD:S, HL2:DM, and SDK 2013 mods), so that we don't grab some older shim of an iface (causing our hooks to not fire).

This should allow seamless functionality now for TF2, both before and after the impending updates for CS:S, DoD:S, and HL2:DM, as well as both SDK 2013 mods that have updated to the newer iface and those that haven't.