### PR TITLE
Factor out SH_DECL_EXTERN macros into variadic versions.

### DIFF
--- a/core/sourcehook/generate/sourcehook.hxx
+++ b/core/sourcehook/generate/sourcehook.hxx
@@ -1072,7 +1072,16 @@ SourceHook::CallClass<T> *SH_GET_CALLCLASS(T *p)
 	buf[sizeof(buf) - 1] = 0; \
 	va_end(ap);
 
+// Helper for MANUALEXTERN.
+# define SHINT_DECL_MANUALEXTERN_impl_value(hookname, rettype) \
+	void __SoureceHook_FHM_SetOverrideResult##hookname(::SourceHook::ISourceHook *shptr, rettype res);
+
+// Helpers for transforming X(__VA_ARGS__, Y) -> Y when __VA_ARGS__ is empty.
+#define SHINT_COLLAPSE0(_T, ...) __VA_ARGS__
+
+//
 // MSVC will automatically remove a trailing comma if __VA_ARGS__ is empty. GCC requires using ## to do this.
+//
 #if defined(_MSC_VER)
 # define SH_DECL_EXTERN(ifacetype, ifacefunc, attr, overload, rettype, ...) \
 	int __SourceHook_FHAdd##ifacetype##ifacefunc(void *iface, ::SourceHook::ISourceHook::AddHookMode mode, bool post, \
@@ -1089,7 +1098,41 @@ SourceHook::CallClass<T> *SH_GET_CALLCLASS(T *p)
 # define SH_DECL_EXTERN_void_vafmt(ifacetype, ifacefunc, attr, overload, ...) \
 	SH_DECL_EXTERN(ifacetype, ifacefunc, attr, overload, void, __VA_ARGS__, const char *)
 
+// Helpers for MANUALEXTERN.
+# define SHINT_DECL_MANUALEXTERN_impl_shared(hookname, rettype, ...) \
+	int __SourceHook_FHMAdd##hookname(void *iface, ::SourceHook::ISourceHook::AddHookMode mode, bool post, \
+		fastdelegate::FastDelegate<rettype, __VA_ARGS__> handler); \
+	bool __SourceHook_FHMRemove##hookname(void *iface, bool post, \
+		fastdelegate::FastDelegate<rettype, __VA_ARGS__> handler); \
+	void __SourceHook_FHM_Reconfigure##hookname(int pvtblindex, int pvtbloffs, int pthisptroffs);
+
+# define SHINT_DECL_MANUALEXTERN_impl(hookname, rettype, ...) \
+	SHINT_DECL_MANUALEXTERN_impl_shared(hookname, rettype, __VA_ARGS__) \
+	rettype(::SourceHook::EmptyClass::* __SoureceHook_FHM_GetRecallMFP##hookname(::SourceHook::EmptyClass *thisptr) )(__VA_ARGS__); \
+	SourceHook::ExecutableClassN<SourceHook::EmptyClass, rettype(::SourceHook::EmptyClass::*)(__VA_ARGS__), rettype, __VA_ARGS__> __SoureceHook_FHM_SHCall##hookname(void *ptr);
+
+# define SHINT_DECL_MANUALEXTERN_impl_vafmt(hookname, rettype, ...) \
+	SHINT_DECL_MANUALEXTERN_impl_shared(hookname, rettype, __VA_ARGS__, const char *) \
+	rettype(::SourceHook::EmptyClass::* __SoureceHook_FHM_GetRecallMFP##hookname(::SourceHook::EmptyClass *thisptr) )(SHINT_COLLAPSE0(void, __VA_ARGS__, const char *, ...)); \
+	SourceHook::ExecutableClassN<SourceHook::EmptyClass, rettype(::SourceHook::EmptyClass::*)(SHINT_COLLAPSE0(void, __VA_ARGS__, const char *, ...)), rettype, __VA_ARGS__, const char *> __SoureceHook_FHM_SHCall##hookname(void *ptr);
+
+# define SH_DECL_MANUALEXTERN(hookname, rettype, ...) \
+	SHINT_DECL_MANUALEXTERN_impl(hookname, rettype, __VA_ARGS__) \
+	SHINT_DECL_MANUALEXTERN_impl_value(hookname, rettype)
+
+# define SH_DECL_MANUALEXTERN_void(hookname, ...) \
+	SHINT_DECL_MANUALEXTERN_impl(hookname, void, __VA_ARGS__)
+
+# define SH_DECL_MANUALEXTERN_void_vafmt(hookname, ...) \
+	SHINT_DECL_MANUALEXTERN_impl_vafmt(hookname, void, __VA_ARGS__)
+
+# define SH_DECL_MANUALEXTERN_vafmt(hookname, rettype, ...) \
+	SHINT_DECL_MANUALEXTERN_impl_vafmt(hookname, rettype, __VA_ARGS__) \
+	SHINT_DECL_MANUALEXTERN_impl_value(hookname, rettype)
+
+//
 // GCC Implementation.
+//
 #else
 # define SH_DECL_EXTERN(ifacetype, ifacefunc, attr, overload, rettype, ...) \
 	int __SourceHook_FHAdd##ifacetype##ifacefunc(void *iface, ::SourceHook::ISourceHook::AddHookMode mode, bool post, \
@@ -1105,6 +1148,38 @@ SourceHook::CallClass<T> *SH_GET_CALLCLASS(T *p)
 
 # define SH_DECL_EXTERN_void_vafmt(ifacetype, ifacefunc, attr, overload, ...) \
 	SH_DECL_EXTERN(ifacetype, ifacefunc, attr, overload, void, ##__VA_ARGS__, const char *)
+
+// Helpers for MANUALEXTERN.
+# define SHINT_DECL_MANUALEXTERN_impl_shared(hookname, rettype, ...) \
+	int __SourceHook_FHMAdd##hookname(void *iface, ::SourceHook::ISourceHook::AddHookMode mode, bool post, \
+		fastdelegate::FastDelegate<rettype, ##__VA_ARGS__> handler); \
+	bool __SourceHook_FHMRemove##hookname(void *iface, bool post, \
+		fastdelegate::FastDelegate<rettype, ##__VA_ARGS__> handler); \
+	void __SourceHook_FHM_Reconfigure##hookname(int pvtblindex, int pvtbloffs, int pthisptroffs);
+
+# define SHINT_DECL_MANUALEXTERN_impl(hookname, rettype, ...) \
+	SHINT_DECL_MANUALEXTERN_impl_shared(hookname, rettype, ##__VA_ARGS__) \
+	rettype(::SourceHook::EmptyClass::* __SoureceHook_FHM_GetRecallMFP##hookname(::SourceHook::EmptyClass *thisptr) )(__VA_ARGS__); \
+	SourceHook::ExecutableClassN<SourceHook::EmptyClass, rettype(::SourceHook::EmptyClass::*)(__VA_ARGS__), rettype, ##__VA_ARGS__> __SoureceHook_FHM_SHCall##hookname(void *ptr);
+
+# define SHINT_DECL_MANUALEXTERN_impl_vafmt(hookname, rettype, ...) \
+	SHINT_DECL_MANUALEXTERN_impl_shared(hookname, rettype, ##__VA_ARGS__, const char *) \
+	rettype(::SourceHook::EmptyClass::* __SoureceHook_FHM_GetRecallMFP##hookname(::SourceHook::EmptyClass *thisptr) )(SHINT_COLLAPSE0(void, ##__VA_ARGS__, const char *, ...)); \
+	SourceHook::ExecutableClassN<SourceHook::EmptyClass, rettype(::SourceHook::EmptyClass::*)(SHINT_COLLAPSE0(void, ##__VA_ARGS__, const char *, ...)), rettype, ##__VA_ARGS__, const char *> __SoureceHook_FHM_SHCall##hookname(void *ptr);
+
+# define SH_DECL_MANUALEXTERN(hookname, rettype, ...) \
+	SHINT_DECL_MANUALEXTERN_impl(hookname, rettype, ##__VA_ARGS__) \
+	SHINT_DECL_MANUALEXTERN_impl_value(hookname, rettype)
+
+# define SH_DECL_MANUALEXTERN_void(hookname, ...) \
+	SHINT_DECL_MANUALEXTERN_impl(hookname, void, ##__VA_ARGS__)
+
+# define SH_DECL_MANUALEXTERN_void_vafmt(hookname, ...) \
+	SHINT_DECL_MANUALEXTERN_impl_vafmt(hookname, void, ##__VA_ARGS__)
+
+# define SH_DECL_MANUALEXTERN_vafmt(hookname, rettype, ...) \
+	SHINT_DECL_MANUALEXTERN_impl_vafmt(hookname, rettype, ##__VA_ARGS__) \
+	SHINT_DECL_MANUALEXTERN_impl_value(hookname, rettype)
 
 #endif
 
@@ -1210,14 +1285,7 @@ SourceHook::CallClass<T> *SH_GET_CALLCLASS(T *p)
 	}
 
 #define SH_DECL_MANUALEXTERN$1(hookname, rettype@[$2,1,$1:, param$2@]) \
-	int __SourceHook_FHMAdd##hookname(void *iface, ::SourceHook::ISourceHook::AddHookMode mode, bool post, \
-		fastdelegate::FastDelegate<rettype@[$2,1,$1|:, param$2@]> handler); \
-	bool __SourceHook_FHMRemove##hookname(void *iface, bool post, \
-		fastdelegate::FastDelegate<rettype@[$2,1,$1|:, param$2@]> handler); \
-	rettype(::SourceHook::EmptyClass::* __SoureceHook_FHM_GetRecallMFP##hookname(::SourceHook::EmptyClass *thisptr) )(@[$2,1,$1|, :param$2@]); \
-	SourceHook::ExecutableClassN<SourceHook::EmptyClass, rettype(::SourceHook::EmptyClass::*)(@[$2,1,$1|, :param$2@]), rettype@[$2,1,$1:, param$2@]> __SoureceHook_FHM_SHCall##hookname(void *ptr); \
-	void __SoureceHook_FHM_SetOverrideResult##hookname(::SourceHook::ISourceHook *shptr, rettype res); \
-	void __SourceHook_FHM_Reconfigure##hookname(int pvtblindex, int pvtbloffs, int pthisptroffs);
+	SH_DECL_MANUALEXTERN(hookname, rettype@[$2,1,$1|:, param$2@])
 
 #define SH_DECL_MANUALHOOK$1_vafmt(hookname, vtblidx, vtbloffs, thisptroffs, rettype@[$2,1,$1:, param$2@]) \
 	SHINT_MAKE_GENERICSTUFF_BEGIN_MANUAL(hookname, vtbloffs, vtblidx, thisptroffs) \
@@ -1243,14 +1311,7 @@ SourceHook::CallClass<T> *SH_GET_CALLCLASS(T *p)
 	}
 
 #define SH_DECL_MANUALEXTERN$1_vafmt(hookname, rettype@[$2,1,$1:, param$2@]) \
-	int __SourceHook_FHMAdd##hookname(void *iface, ::SourceHook::ISourceHook::AddHookMode mode, bool post, \
-		fastdelegate::FastDelegate<rettype, @[$2,1,$1:param$2, @]const char *> handler); \
-	bool __SourceHook_FHMRemove##hookname(void *iface, bool post, \
-		fastdelegate::FastDelegate<rettype, @[$2,1,$1:param$2, @]const char *> handler); \
-	rettype(::SourceHook::EmptyClass::* __SoureceHook_FHM_GetRecallMFP##hookname(::SourceHook::EmptyClass *thisptr) )(@[$2,1,$1:param$2, @]const char *, ...); \
-	SourceHook::ExecutableClassN<SourceHook::EmptyClass, rettype(::SourceHook::EmptyClass::*)(@[$2,1,$1:param$2, @]const char *, ...), rettype@[$2,1,$1:, param$2@], const char*> __SoureceHook_FHM_SHCall##hookname(void *ptr); \
-	void __SoureceHook_FHM_SetOverrideResult##hookname(::SourceHook::ISourceHook *shptr, rettype res); \
-	void __SourceHook_FHM_Reconfigure##hookname(int pvtblindex, int pvtbloffs, int pthisptroffs);
+	SH_DECL_MANUALEXTERN_vafmt(hookname, rettype@[$1!=0:, @]@[$2,1,$1|, :param$2@])
 
 #define SH_DECL_MANUALHOOK$1_void(hookname, vtblidx, vtbloffs, thisptroffs@[$2,1,$1:, param$2@]) \
 	SHINT_MAKE_GENERICSTUFF_BEGIN_MANUAL(hookname, vtbloffs, vtblidx, thisptroffs) \
@@ -1268,13 +1329,7 @@ SourceHook::CallClass<T> *SH_GET_CALLCLASS(T *p)
 		__SourceHook_ParamInfosM_##hookname	, 0, __SH_EPI, __SourceHook_ParamInfos2M_##hookname };
 
 #define SH_DECL_MANUALEXTERN$1_void(hookname@[$2,1,$1:, param$2@]) \
-	int __SourceHook_FHMAdd##hookname(void *iface, ::SourceHook::ISourceHook::AddHookMode mode, bool post, \
-		fastdelegate::FastDelegate<void@[$1!=0:, @]@[$2,1,$1|, :param$2@]> handler); \
-	bool __SourceHook_FHMRemove##hookname(void *iface, bool post, \
-		fastdelegate::FastDelegate<void@[$1!=0:, @]@[$2,1,$1|, :param$2@]> handler); \
-	void(::SourceHook::EmptyClass::* __SoureceHook_FHM_GetRecallMFP##hookname(::SourceHook::EmptyClass *thisptr) )(@[$2,1,$1|, :param$2@]); \
-	SourceHook::ExecutableClassN<SourceHook::EmptyClass, void(::SourceHook::EmptyClass::*)(@[$2,1,$1|, :param$2@]), void@[$2,1,$1:, param$2@]> __SoureceHook_FHM_SHCall##hookname(void *ptr); \
-	void __SourceHook_FHM_Reconfigure##hookname(int pvtblindex, int pvtbloffs, int pthisptroffs);
+	SH_DECL_MANUALEXTERN_void(hookname@[$1!=0:, @]@[$2,1,$1|, :param$2@])
 
 #define SH_DECL_MANUALHOOK$1_void_vafmt(hookname, vtblidx, vtbloffs, thisptroffs@[$2,1,$1:, param$2@]) \
 	SHINT_MAKE_GENERICSTUFF_BEGIN_MANUAL(hookname, vtbloffs, vtblidx, thisptroffs) \
@@ -1295,13 +1350,8 @@ SourceHook::CallClass<T> *SH_GET_CALLCLASS(T *p)
 		__SourceHook_ParamInfosM_##hookname	, 0, __SH_EPI, __SourceHook_ParamInfos2M_##hookname };
 
 #define SH_DECL_MANUALEXTERN$1_void_vafmt(hookname@[$2,1,$1:, param$2@]) \
-	int __SourceHook_FHMAdd##hookname(void *iface, ::SourceHook::ISourceHook::AddHookMode mode, bool post, \
-		fastdelegate::FastDelegate<void, @[$2,1,$1:param$2, @]const char *> handler); \
-	bool __SourceHook_FHMRemove##hookname(void *iface, bool post, \
-		fastdelegate::FastDelegate<void, @[$2,1,$1:param$2, @]const char *> handler); \
-	void(::SourceHook::EmptyClass::* __SoureceHook_FHM_GetRecallMFP##hookname(::SourceHook::EmptyClass *thisptr) )(@[$2,1,$1:param$2, @]const char *, ...); \
-	SourceHook::ExecutableClassN<SourceHook::EmptyClass, void(::SourceHook::EmptyClass::*)(@[$2,1,$1:param$2, @]const char *, ...), void@[$2,1,$1:, param$2@], const char*> __SoureceHook_FHM_SHCall##hookname(void *ptr); \
-	void __SourceHook_FHM_Reconfigure##hookname(int pvtblindex, int pvtbloffs, int pthisptroffs);
+	SH_DECL_MANUALEXTERN_void_vafmt(hookname@[$1!=0:, @]@[$2,1,$1|, :param$2@])
+
 @]
 
 


### PR DESCRIPTION
This adds SH_DECL_EXTERN and SH_DECL_MANUALEXTERN macros that can be used with variadic arguments rather than a fixed identifier. Unfortunately I couldn't get rid of the 0 case (meaning most 0-arg macros still need something like SH_DECL_MANUALEXTERN0), since the GCC (and possibly MSVC) preprocessors will turn this:

    #define A(...) (__VA_ARGS__)
    #define B(...) A(__VA_ARGS__, const char *)
    B()

Into this:

    (, const char *)