### PR TITLE
Allow support for running on filesystems that use 64-bit inodes on Linux.

### DIFF
--- a/AMBuildScript
+++ b/AMBuildScript
@@ -217,7 +217,7 @@ class MMSConfig(object):
 
     # Platform-specifics
     if builder.target_platform == 'linux':
-      cfg.defines += ['_LINUX', 'POSIX']
+      cfg.defines += ['_LINUX', 'POSIX', '_FILE_OFFSET_BITS=64']
       if cxx.name == 'gcc':
         cfg.linkflags += ['-static-libgcc']
       elif cxx.name == 'clang':


### PR DESCRIPTION
Most supported games don't even support this case, but at least CS:GO does. WIthout
this fix, some filesystem calls can fail, or in the case of readdir, fail to return all/any files.
This was first observed when using an XFS-formatted volume on CentOS 7 x64.

@asherkin 