### PR TITLE
{sample,stub}_mm: Ignore GCC delete-non-virtual-dtor error

### DIFF
--- a/sample_mm/Makefile
+++ b/sample_mm/Makefile
@@ -26,7 +26,7 @@ OBJECTS = sample_mm.cpp
 ##############################################
 
 OPT_FLAGS = -O3 -funroll-loops -pipe
-GCC4_FLAGS = -fvisibility=hidden -fvisibility-inlines-hidden -std=c++11
+GCC4_FLAGS = -fvisibility=hidden -fvisibility-inlines-hidden -std=c++11 -Wno-error=delete-non-virtual-dtor
 DEBUG_FLAGS = -g -ggdb3 -D_DEBUG
 CPP = gcc
 CPP_OSX = clang

--- a/stub_mm/Makefile
+++ b/stub_mm/Makefile
@@ -26,7 +26,7 @@ OBJECTS = stub_mm.cpp
 ##############################################
 
 OPT_FLAGS = -O3 -funroll-loops -pipe
-GCC4_FLAGS = -fvisibility=hidden -fvisibility-inlines-hidden
+GCC4_FLAGS = -fvisibility=hidden -fvisibility-inlines-hidden -Wno-error=delete-non-virtual-dtor
 DEBUG_FLAGS = -g -ggdb3 -D_DEBUG
 CPP = gcc
 CPP_OSX = clang


### PR DESCRIPTION
Needed for compiling with GCC newer than 4.7<=.

---

The delete-non-virtual-dtor issue should properly be fixed, but Sourcemod also just seems to ignore them so..