### PR TITLE
Fix linking errors with some compilers when MM:S plugins call function in tier1 interface.h.

### DIFF
--- a/core/ISmmPlugin.h
+++ b/core/ISmmPlugin.h
@@ -39,6 +39,10 @@
 #include <ISmmAPI.h>
 #include <ISmmPluginExt.h>
 
+#ifndef META_NO_HL2SDK
+#include <tier1/interface.h>
+#endif
+
 class IServerPluginCallbacks;
 
 // Interface return status, binary-compatible with HL2SDK's IFACE_OK and IFACE_FAILED.
@@ -439,17 +443,29 @@ using namespace SourceMM;
  * 					you should not pass a pointer to your plugin's 
  *					singleton.
  */
-#define PLUGIN_EXPOSE(name, var) \
-	ISmmAPI *g_SMAPI = NULL; \
-	ISmmPlugin *g_PLAPI = NULL; \
-	PluginId g_PLID = (PluginId)0; \
-	SourceHook::ISourceHook *g_SHPtr = NULL; \
+#ifdef META_NO_HL2SDK
+#define PL_EXPOSURE_FUNC(name, var) \
 	SMM_API void *PL_EXPOSURE(const char *name, int *code) { \
 		if (name && !strcmp(name, METAMOD_PLAPI_NAME)) { \
 			return static_cast<void *>(&var); \
 		} \
 		return NULL; \
 	}
+
+#else
+// First param should be actual classname, not iface name, but we don't have that and it doesn't matter here.
+#define PL_EXPOSURE_FUNC(name, var)	EXPOSE_SINGLE_INTERFACE_GLOBALVAR(ISmmPlugin, ISmmPlugin, METAMOD_PLAPI_NAME, var);
+#endif
+
+#define PLUGIN_EXPOSE(name, var) \
+	ISmmAPI *g_SMAPI = NULL; \
+	ISmmPlugin *g_PLAPI = NULL; \
+	PluginId g_PLID = (PluginId)0; \
+	SourceHook::ISourceHook *g_SHPtr = NULL; \
+	PL_EXPOSURE_FUNC(name, var)
+	
+	
+	
 
 
 /**


### PR DESCRIPTION
Currently, if any MM:S plugin (using the PLUGIN_EXPOSE macro) statically links Valve's tier1 library, and makes calls to any of the functions from interface.h/cpp in tier1, some linkers will throw an error due to the CreateInterface export being defined twice.

In this case, there's no reason why we can't use tier1's CreateInterface implementation if it's available. Since we already require the Source SDK by default for MM:S plugins, we can use it in that case. If the META_NO_HL2SDK is defined, we can use the existing implementation.