### PR TITLE
64-bit support for CSGO on Linux and macOS

### DIFF
--- a/AMBuildScript
+++ b/AMBuildScript
@@ -353,7 +353,7 @@ class MMSConfig(object):
         'BINARY_NAME="{0}"'.format(binary.outputFile),
         'RC_COMPILE'
       ]
-    elif builder.target.platform == 'mac':
+    elif builder.target.platform == 'mac' and binary.type == 'library':
       binary.compiler.postlink += [
         '-compatibility_version', '1.0.0',
         '-current_version', self.productVersion

--- a/AMBuildScript
+++ b/AMBuildScript
@@ -91,9 +91,9 @@ def SetArchFlags(compiler, arch, platform):
       if platform == 'mac':
         compiler.linkflags = ['-arch', 'x86_64']
   elif compiler.like('msvc'):
-    if builder.target.arch == 'x86':
+    if arch == 'x86':
       compiler.linkflags += ['/MACHINE:X86']
-    elif builder.target.arch == 'x86_64':
+    elif arch == 'x86_64':
       compiler.linkflags += ['/MACHINE:X64']
 
 def AppendArchSuffix(binary, name, arch):

--- a/AMBuildScript
+++ b/AMBuildScript
@@ -161,6 +161,9 @@ class MMSConfig(object):
       raise Exception('Unknown target architecture: {0}'.format(builder.target.arch))
 
     cxx = builder.DetectCxx()
+    
+    if cxx.like('msvc') and len(self.archs) > 1:
+      raise Exception('Building multiple archs with MSVC is not currently supported')
 
     if cxx.behavior == 'gcc':
       cxx.defines += [

--- a/AMBuildScript
+++ b/AMBuildScript
@@ -18,16 +18,21 @@ class SDK(object):
     else:
       self.platformSpec = platform
 
-  def shouldBuild(self, target):
+  def shouldBuild(self, target, archs):
     if target.platform not in self.platformSpec:
       return False
-    if target.arch not in self.platformSpec[target.platform]:
+    if not len([i for i in self.platformSpec[target.platform] if i in archs]):
       return False
     return True
 
 WinOnly = ['windows']
 WinLinux = ['windows', 'linux']
 WinLinuxMac = ['windows', 'linux', 'mac']
+CSGO = {
+  'windows': ['x86'],
+  'linux': ['x86', 'x86_64'],
+  'mac': ['x86_64']
+}
 Source2 = {
   'windows': ['x86', 'x86_64'],
   'linux': ['x86_64'],
@@ -48,7 +53,7 @@ PossibleSDKs = {
   'swarm':  SDK('HL2SDK-SWARM', '2.swarm', '16', 'ALIENSWARM', WinOnly, 'swarm'),
   'bgt':  SDK('HL2SDK-BGT', '2.bgt', '4', 'BLOODYGOODTIME', WinOnly, 'bgt'),
   'eye':  SDK('HL2SDK-EYE', '2.eye', '5', 'EYE', WinOnly, 'eye'),
-  'csgo': SDK('HL2SDKCSGO', '2.csgo', '20', 'CSGO', WinLinuxMac, 'csgo'),
+  'csgo': SDK('HL2SDKCSGO', '2.csgo', '20', 'CSGO', CSGO, 'csgo'),
   'dota': SDK('HL2SDKDOTA', '2.dota', '21', 'DOTA', Source2, 'dota'),
   'portal2':  SDK('HL2SDKPORTAL2', '2.portal2', '17', 'PORTAL2', [], 'portal2'),
   'blade':  SDK('HL2SDKBLADE', '2.blade', '18', 'BLADE', WinLinux, 'blade'),
@@ -72,6 +77,24 @@ def ResolveEnvPath(env, folder):
       oldhead = head
       head, tail = os.path.split(head)
   return None
+  
+def SetArchFlags(compiler, arch, platform):
+  if compiler.behavior == 'gcc':
+    if arch == 'x86':
+      compiler.cflags += ['-m32']
+      compiler.linkflags += ['-m32']
+      if platform == 'mac':
+        compiler.linkflags = ['-arch', 'i386']
+    elif arch == 'x86_64':
+      compiler.cflags += ['-m64', '-fPIC']
+      compiler.linkflags += ['-m64']
+      if platform == 'mac':
+        compiler.linkflags = ['-arch', 'x86_64']
+  elif compiler.like('msvc'):
+    if builder.target.arch == 'x86':
+      compiler.linkflags += ['/MACHINE:X86']
+    elif builder.target.arch == 'x86_64':
+      compiler.linkflags += ['/MACHINE:X64']
 
 class MMSConfig(object):
   def __init__(self):
@@ -79,6 +102,7 @@ class MMSConfig(object):
     self.binaries = []
     self.generated_headers = None
     self.versionlib = None
+    self.archs = builder.target.arch.split(',')
 
   def use_auto_versioning(self):
     if builder.backend != 'amb2':
@@ -109,7 +133,7 @@ class MMSConfig(object):
 
     for sdk_name in PossibleSDKs:
       sdk = PossibleSDKs[sdk_name]
-      if sdk.shouldBuild(builder.target):
+      if sdk.shouldBuild(builder.target, self.archs):
         if builder.options.hl2sdk_root:
           sdk_path = os.path.join(builder.options.hl2sdk_root, sdk.folder)
         else:
@@ -129,7 +153,7 @@ class MMSConfig(object):
   def configure(self):
     builder.AddConfigureFile('pushbuild.txt')
 
-    if builder.target.arch not in ['x86', 'x86_64']:
+    if not set(self.archs).issubset(['x86', 'x86_64']):
       raise Exception('Unknown target architecture: {0}'.format(builder.target.arch))
 
     cxx = builder.DetectCxx()
@@ -154,13 +178,6 @@ class MMSConfig(object):
         '-msse',
       ]
 
-      if builder.target.arch == 'x86':
-        cxx.cflags += ['-m32']
-        cxx.linkflags += ['-m32']
-      elif builder.target.arch == 'x86_64':
-        cxx.cflags += ['-m64', '-fPIC']
-        cxx.linkflags += ['-m64']
-
       cxx.cxxflags += [ '-std=c++11' ]
       if (cxx.version >= 'gcc-4.0') or cxx.family == 'clang':
         cxx.cflags += ['-fvisibility=hidden']
@@ -178,7 +195,7 @@ class MMSConfig(object):
         cxx.cflags += ['-mfpmath=sse']
       if cxx.family == 'clang':
         cxx.cxxflags += ['-Wno-implicit-exception-spec-mismatch']
-        if cxx.version >= 'clang-3.6':
+        if cxx.version >= 'clang-3.6' or cxx.version >= 'apple-clang-7.0':
           cxx.cxxflags += ['-Wno-inconsistent-missing-override']
         if cxx.version >= 'apple-clang-5.1' or cxx.version >= 'clang-3.4':
           cxx.cxxflags += ['-Wno-deprecated-register']
@@ -201,11 +218,6 @@ class MMSConfig(object):
         '/Zi',
       ]
       cxx.cxxflags += ['/TP']
-	  
-      if builder.target.arch == 'x86':
-        cxx.linkflags += ['/MACHINE:X86']
-      elif builder.target.arch == 'x86_64':
-        cxx.linkflags += ['/MACHINE:X64']
       
       cxx.linkflags += [
         '/SUBSYSTEM:WINDOWS',
@@ -254,11 +266,10 @@ class MMSConfig(object):
         cxx.linkflags += ['-lgcc_eh']
     elif builder.target.platform == 'mac':
       cxx.defines += ['OSX', '_OSX', 'POSIX']
-      cxx.cflags += ['-mmacosx-version-min=10.5']
+      cxx.cflags += ['-mmacosx-version-min=10.9']
       cxx.linkflags += [
-        '-mmacosx-version-min=10.5',
-        '-arch', 'i386',
-        '-lstdc++',
+        '-mmacosx-version-min=10.9',
+        '-lc++',
       ]
     elif builder.target.platform == 'windows':
       cxx.defines += ['WIN32', '_WINDOWS']
@@ -275,7 +286,7 @@ class MMSConfig(object):
         os.path.join(builder.sourcePath, 'versionlib'),
       ]
 
-  def HL2Compiler(self, context, sdk):
+  def HL2Compiler(self, context, sdk, arch):
     compiler = context.cxx.clone()
     compiler.cxxincludes += [
       os.path.join(context.currentSourcePath),
@@ -309,17 +320,17 @@ class MMSConfig(object):
 
     if compiler.family == 'msvc':
       compiler.defines += ['COMPILER_MSVC']
-      if builder.target.arch == 'x86':
+      if arch == 'x86':
         compiler.defines += ['COMPILER_MSVC32']
-      elif builder.target.arch == 'x86_64':
+      elif arch == 'x86_64':
         compiler.defines += ['COMPILER_MSVC64']
       
       if compiler.version >= 1900:
         compiler.linkflags += ['legacy_stdio_definitions.lib']
     else:
       compiler.defines += ['COMPILER_GCC']
-
-    if sdk.name == 'dota' and builder.target.arch == 'x86_64':
+      
+    if arch == 'x86_64':
       compiler.defines += ['X64BITS', 'PLATFORM_64BITS']
 
     if sdk.name in ['css', 'hl2dm', 'dods', 'sdk2013', 'bms', 'tf2', 'l4d', 'nucleardawn', 'l4d2', 'dota']:
@@ -335,7 +346,7 @@ class MMSConfig(object):
 
     return compiler
 
-  def AddVersioning(self, binary):
+  def AddVersioning(self, binary, arch):
     if builder.target.platform == 'windows':
       binary.sources += ['version.rc']
       binary.compiler.rcdefines += [
@@ -348,20 +359,20 @@ class MMSConfig(object):
         '-current_version', self.productVersion
       ]
     if self.use_auto_versioning():
-      binary.compiler.linkflags += [self.versionlib]
+      binary.compiler.linkflags += [self.versionlib[arch]]
       binary.compiler.sourcedeps += MMS.generated_headers
     if builder.options.breakpad_dump:
       binary.compiler.symbol_files = 'separate'
     return binary
 
-  def LibraryBuilder(self, compiler, name):
+  def LibraryBuilder(self, compiler, name, arch):
     binary = compiler.Library(name)
-    self.AddVersioning(binary)
+    self.AddVersioning(binary, arch)
     return binary
 
-  def ProgramBuilder(self, compiler, name):
+  def ProgramBuilder(self, compiler, name, arch):
     binary = compiler.Program(name)
-    self.AddVersioning(binary)
+    self.AddVersioning(binary, arch)
     if '-static-libgcc' in binary.compiler.linkflags:
       binary.compiler.linkflags.remove('-static-libgcc')
     if '-lgcc_eh' in binary.compiler.linkflags:
@@ -369,17 +380,30 @@ class MMSConfig(object):
     if binary.compiler.like('gcc'):
       binary.compiler.linkflags += ['-lstdc++']
     return binary
+    
+  def StaticLibraryBuilder(self, compiler, name):
+    binary = compiler.StaticLibrary(name)
+    return binary;
 
-  def Library(self, context, name):
+  def Library(self, context, name, arch):
     compiler = context.cxx.clone()
-    return self.LibraryBuilder(compiler, name)
+    SetArchFlags(compiler, arch, builder.target.platform)
+    return self.LibraryBuilder(compiler, name, arch)
 
-  def Program(self, context, name):
+  def Program(self, context, name, arch):
     compiler = context.cxx.clone()
-    return self.ProgramBuilder(compiler, name)
+    SetArchFlags(compiler, arch, builder.target.platform)
+    return self.ProgramBuilder(compiler, name, arch)
+    
+  def StaticLibrary(self, context, name, arch):
+    compiler = context.cxx.clone()
+    SetArchFlags(compiler, arch, builder.target.platform)
+    return self.StaticLibraryBuilder(compiler, name)
 
-  def HL2Library(self, context, name, sdk):
-    compiler = self.HL2Compiler(context, sdk)
+  def HL2Library(self, context, name, sdk, arch):
+    compiler = self.HL2Compiler(context, sdk, arch)
+    
+    SetArchFlags(compiler, arch, builder.target.platform)
 
     if builder.target.platform == 'linux':
       if sdk.name == 'episode1':
@@ -391,19 +415,27 @@ class MMSConfig(object):
     elif builder.target.platform == 'mac':
       if sdk.name in ['sdk2013', 'bms']:
         lib_folder = os.path.join(sdk.path, 'lib', 'public', 'osx32')
+      elif arch == 'x86_64':
+        lib_folder = os.path.join(sdk.path, 'lib', 'osx64')
       else:
         lib_folder = os.path.join(sdk.path, 'lib', 'mac')
 
     if builder.target.platform in ['linux', 'mac']:
-      if sdk.name in ['sdk2013', 'bms']:
+      if sdk.name in ['sdk2013', 'bms'] or arch == 'x86_64':
         compiler.postlink += [compiler.Dep(os.path.join(lib_folder, 'tier1.a'))]
       else:
         compiler.postlink += [compiler.Dep(os.path.join(lib_folder, 'tier1_i486.a'))]
 
       if sdk.name in ['blade', 'insurgency', 'csgo', 'dota']:
-        compiler.postlink += [compiler.Dep(os.path.join(lib_folder, 'interfaces_i486.a'))]
+        if arch == 'x86_64':
+          compiler.postlink += [compiler.Dep(os.path.join(lib_folder, 'interfaces.a'))]
+        else:
+          compiler.postlink += [compiler.Dep(os.path.join(lib_folder, 'interfaces_i486.a'))]
 
-    binary = self.LibraryBuilder(compiler, name)
+    binary = self.LibraryBuilder(compiler, name, arch)
+
+    if arch == 'x86_64':
+      binary.localFolder = name + ".x64"
 
     dynamic_libs = []
     if builder.target.platform == 'linux':
@@ -422,9 +454,9 @@ class MMSConfig(object):
       if sdk.name in ['swarm', 'blade', 'insurgency', 'csgo', 'dota']:
         libs.append('interfaces')
       for lib in libs:
-        if builder.target.arch == 'x86':
+        if arch == 'x86':
           lib_path = os.path.join(sdk.path, 'lib', 'public', lib) + '.lib'
-        elif builder.target.arch == 'x86_64':
+        elif arch == 'x86_64':
           lib_path = os.path.join(sdk.path, 'lib', 'public', 'win64', lib) + '.lib'
         binary.compiler.linkflags.append(binary.Dep(lib_path))
 

--- a/AMBuildScript
+++ b/AMBuildScript
@@ -84,12 +84,12 @@ def SetArchFlags(compiler, arch, platform):
       compiler.cflags += ['-m32']
       compiler.linkflags += ['-m32']
       if platform == 'mac':
-        compiler.linkflags = ['-arch', 'i386']
+        compiler.linkflags += ['-arch', 'i386']
     elif arch == 'x86_64':
       compiler.cflags += ['-m64', '-fPIC']
       compiler.linkflags += ['-m64']
       if platform == 'mac':
-        compiler.linkflags = ['-arch', 'x86_64']
+        compiler.linkflags += ['-arch', 'x86_64']
   elif compiler.like('msvc'):
     if arch == 'x86':
       compiler.linkflags += ['/MACHINE:X86']

--- a/AMBuildScript
+++ b/AMBuildScript
@@ -30,12 +30,12 @@ WinLinux = ['windows', 'linux']
 WinLinuxMac = ['windows', 'linux', 'mac']
 CSGO = {
   'windows': ['x86'],
-  'linux': ['x86', 'x86_64'],
-  'mac': ['x86_64']
+  'linux': ['x86', 'x64'],
+  'mac': ['x64']
 }
 Source2 = {
-  'windows': ['x86', 'x86_64'],
-  'linux': ['x86_64'],
+  'windows': ['x86', 'x64'],
+  'linux': ['x64'],
 }
 
 PossibleSDKs = {
@@ -85,7 +85,7 @@ def SetArchFlags(compiler, arch, platform):
       compiler.linkflags += ['-m32']
       if platform == 'mac':
         compiler.linkflags += ['-arch', 'i386']
-    elif arch == 'x86_64':
+    elif arch == 'x64':
       compiler.cflags += ['-m64', '-fPIC']
       compiler.linkflags += ['-m64']
       if platform == 'mac':
@@ -93,11 +93,11 @@ def SetArchFlags(compiler, arch, platform):
   elif compiler.like('msvc'):
     if arch == 'x86':
       compiler.linkflags += ['/MACHINE:X86']
-    elif arch == 'x86_64':
+    elif arch == 'x64':
       compiler.linkflags += ['/MACHINE:X64']
 
 def AppendArchSuffix(binary, name, arch):
-  if arch == 'x86_64':
+  if arch == 'x64':
     binary.localFolder = name + '.x64'
 
 class MMSConfig(object):
@@ -106,13 +106,12 @@ class MMSConfig(object):
     self.binaries = []
     self.generated_headers = None
     self.versionlib = None
-    self.archs = builder.target.arch.split(',')
+    self.archs = builder.target.arch.replace('x86_64', 'x64').split(',')
 
   def use_auto_versioning(self):
     if builder.backend != 'amb2':
       return False
     return not getattr(builder.options, 'disable_auto_versioning', False)
-
 
   def detectProductVersion(self):
     builder.AddConfigureFile('product.version')
@@ -157,7 +156,7 @@ class MMSConfig(object):
   def configure(self):
     builder.AddConfigureFile('pushbuild.txt')
 
-    if not set(self.archs).issubset(['x86', 'x86_64']):
+    if not set(self.archs).issubset(['x86', 'x64']):
       raise Exception('Unknown target architecture: {0}'.format(builder.target.arch))
 
     cxx = builder.DetectCxx()
@@ -329,7 +328,7 @@ class MMSConfig(object):
       compiler.defines += ['COMPILER_MSVC']
       if arch == 'x86':
         compiler.defines += ['COMPILER_MSVC32']
-      elif arch == 'x86_64':
+      elif arch == 'x64':
         compiler.defines += ['COMPILER_MSVC64']
       
       if compiler.version >= 1900:
@@ -337,7 +336,7 @@ class MMSConfig(object):
     else:
       compiler.defines += ['COMPILER_GCC']
       
-    if arch == 'x86_64':
+    if arch == 'x64':
       compiler.defines += ['X64BITS', 'PLATFORM_64BITS']
 
     if sdk.name in ['css', 'hl2dm', 'dods', 'sdk2013', 'bms', 'tf2', 'l4d', 'nucleardawn', 'l4d2', 'dota']:
@@ -420,26 +419,26 @@ class MMSConfig(object):
         lib_folder = os.path.join(sdk.path, 'linux_sdk')
       elif sdk.name in ['sdk2013', 'bms']:
         lib_folder = os.path.join(sdk.path, 'lib', 'public', 'linux32')
-      elif arch == 'x86_64':
+      elif arch == 'x64':
         lib_folder = os.path.join(sdk.path, 'lib', 'linux64')
       else:
         lib_folder = os.path.join(sdk.path, 'lib', 'linux')
     elif builder.target.platform == 'mac':
       if sdk.name in ['sdk2013', 'bms']:
         lib_folder = os.path.join(sdk.path, 'lib', 'public', 'osx32')
-      elif arch == 'x86_64':
+      elif arch == 'x64':
         lib_folder = os.path.join(sdk.path, 'lib', 'osx64')
       else:
         lib_folder = os.path.join(sdk.path, 'lib', 'mac')
 
     if builder.target.platform in ['linux', 'mac']:
-      if sdk.name in ['sdk2013', 'bms'] or arch == 'x86_64':
+      if sdk.name in ['sdk2013', 'bms'] or arch == 'x64':
         compiler.postlink += [compiler.Dep(os.path.join(lib_folder, 'tier1.a'))]
       else:
         compiler.postlink += [compiler.Dep(os.path.join(lib_folder, 'tier1_i486.a'))]
 
       if sdk.name in ['blade', 'insurgency', 'csgo', 'dota']:
-        if arch == 'x86_64':
+        if arch == 'x64':
           compiler.postlink += [compiler.Dep(os.path.join(lib_folder, 'interfaces.a'))]
         else:
           compiler.postlink += [compiler.Dep(os.path.join(lib_folder, 'interfaces_i486.a'))]
@@ -451,7 +450,7 @@ class MMSConfig(object):
       compiler.linkflags[0:0] = ['-lm']
       if sdk.name in ['css', 'hl2dm', 'dods', 'tf2', 'sdk2013', 'bms', 'nucleardawn', 'l4d2', 'insurgency']:
         dynamic_libs = ['libtier0_srv.so', 'libvstdlib_srv.so']
-      elif arch == 'x86_64' and sdk.name == 'csgo':
+      elif arch == 'x64' and sdk.name == 'csgo':
         dynamic_libs = ['libtier0_client.so', 'libvstdlib_client.so']
       elif sdk.name in ['l4d', 'blade', 'insurgency', 'csgo', 'dota']:
         dynamic_libs = ['libtier0.so', 'libvstdlib.so']
@@ -467,7 +466,7 @@ class MMSConfig(object):
       for lib in libs:
         if arch == 'x86':
           lib_path = os.path.join(sdk.path, 'lib', 'public', lib) + '.lib'
-        elif arch == 'x86_64':
+        elif arch == 'x64':
           lib_path = os.path.join(sdk.path, 'lib', 'public', 'win64', lib) + '.lib'
         binary.compiler.linkflags.append(binary.Dep(lib_path))
 

--- a/AMBuildScript
+++ b/AMBuildScript
@@ -270,9 +270,9 @@ class MMSConfig(object):
         cxx.linkflags += ['-lgcc_eh']
     elif builder.target.platform == 'mac':
       cxx.defines += ['OSX', '_OSX', 'POSIX']
-      cxx.cflags += ['-mmacosx-version-min=10.9']
+      cxx.cflags += ['-mmacosx-version-min=10.5']
       cxx.linkflags += [
-        '-mmacosx-version-min=10.9',
+        '-mmacosx-version-min=10.5',
         '-lc++',
       ]
     elif builder.target.platform == 'windows':

--- a/AMBuildScript
+++ b/AMBuildScript
@@ -96,6 +96,10 @@ def SetArchFlags(compiler, arch, platform):
     elif builder.target.arch == 'x86_64':
       compiler.linkflags += ['/MACHINE:X64']
 
+def AppendArchSuffix(binary, name, arch):
+  if arch == 'x86_64':
+    binary.localFolder = name + '.x64'
+
 class MMSConfig(object):
   def __init__(self):
     self.sdks = {}
@@ -367,11 +371,13 @@ class MMSConfig(object):
 
   def LibraryBuilder(self, compiler, name, arch):
     binary = compiler.Library(name)
+    AppendArchSuffix(binary, name, arch)
     self.AddVersioning(binary, arch)
     return binary
 
   def ProgramBuilder(self, compiler, name, arch):
     binary = compiler.Program(name)
+    AppendArchSuffix(binary, name, arch)
     self.AddVersioning(binary, arch)
     if '-static-libgcc' in binary.compiler.linkflags:
       binary.compiler.linkflags.remove('-static-libgcc')
@@ -381,8 +387,9 @@ class MMSConfig(object):
       binary.compiler.linkflags += ['-lstdc++']
     return binary
     
-  def StaticLibraryBuilder(self, compiler, name):
+  def StaticLibraryBuilder(self, compiler, name, arch):
     binary = compiler.StaticLibrary(name)
+    AppendArchSuffix(binary, name, arch)
     return binary;
 
   def Library(self, context, name, arch):
@@ -398,7 +405,7 @@ class MMSConfig(object):
   def StaticLibrary(self, context, name, arch):
     compiler = context.cxx.clone()
     SetArchFlags(compiler, arch, builder.target.platform)
-    return self.StaticLibraryBuilder(compiler, name)
+    return self.StaticLibraryBuilder(compiler, name, arch)
 
   def HL2Library(self, context, name, sdk, arch):
     compiler = self.HL2Compiler(context, sdk, arch)
@@ -435,9 +442,6 @@ class MMSConfig(object):
           compiler.postlink += [compiler.Dep(os.path.join(lib_folder, 'interfaces_i486.a'))]
 
     binary = self.LibraryBuilder(compiler, name, arch)
-
-    if arch == 'x86_64':
-      binary.localFolder = name + ".x64"
 
     dynamic_libs = []
     if builder.target.platform == 'linux':

--- a/AMBuildScript
+++ b/AMBuildScript
@@ -410,6 +410,8 @@ class MMSConfig(object):
         lib_folder = os.path.join(sdk.path, 'linux_sdk')
       elif sdk.name in ['sdk2013', 'bms']:
         lib_folder = os.path.join(sdk.path, 'lib', 'public', 'linux32')
+      elif arch == 'x86_64':
+        lib_folder = os.path.join(sdk.path, 'lib', 'linux64')
       else:
         lib_folder = os.path.join(sdk.path, 'lib', 'linux')
     elif builder.target.platform == 'mac':
@@ -442,6 +444,8 @@ class MMSConfig(object):
       compiler.linkflags[0:0] = ['-lm']
       if sdk.name in ['css', 'hl2dm', 'dods', 'tf2', 'sdk2013', 'bms', 'nucleardawn', 'l4d2', 'insurgency']:
         dynamic_libs = ['libtier0_srv.so', 'libvstdlib_srv.so']
+      elif arch == 'x86_64' and sdk.name == 'csgo':
+        dynamic_libs = ['libtier0_client.so', 'libvstdlib_client.so']
       elif sdk.name in ['l4d', 'blade', 'insurgency', 'csgo', 'dota']:
         dynamic_libs = ['libtier0.so', 'libvstdlib.so']
       else:

--- a/configure.py
+++ b/configure.py
@@ -1,7 +1,7 @@
 # vim: set sts=2 ts=8 sw=2 tw=99 et:
 import sys
 try:
-  from ambuild2 import run
+  from ambuild2 import run, util
 except:
   try:
     import ambuild
@@ -13,7 +13,7 @@ except:
   sys.exit(1)
 
 def make_objdir_name(p):
-  return 'obj-linux-' + p.target_arch
+    return 'obj-' + util.Platform() + '-' + p.target_arch
 
 parser = run.BuildParser(sourcePath=sys.path[0], api='2.1')
 parser.default_arch = 'x86'

--- a/core/AMBuilder
+++ b/core/AMBuilder
@@ -2,30 +2,34 @@
 import os
 
 for sdk_name in MMS.sdks:
-  sdk = MMS.sdks[sdk_name]
+  for arch in MMS.archs:
+    sdk = MMS.sdks[sdk_name]
 
-  name = 'metamod.' + sdk.ext
-  binary = MMS.HL2Library(builder, name, sdk)
+    if not arch in sdk.platformSpec[builder.target.platform]:
+      continue
 
-  binary.sources += [
-    'metamod.cpp',
-    'metamod_console.cpp',
-    'metamod_oslink.cpp',
-    'metamod_plugins.cpp',
-    'metamod_util.cpp',
-    'provider/console.cpp',
-    'provider/provider_ep2.cpp',
-    'sourcehook/sourcehook.cpp',
-    'sourcehook/sourcehook_impl_chookidman.cpp',
-    'sourcehook/sourcehook_impl_chookmaninfo.cpp',
-    'sourcehook/sourcehook_impl_cproto.cpp',
-    'sourcehook/sourcehook_impl_cvfnptr.cpp',
-    'gamedll_bridge.cpp',
-    'vsp_bridge.cpp'
-  ]
+    name = 'metamod.' + sdk.ext
+    binary = MMS.HL2Library(builder, name, sdk, arch)
 
-  # Source2 hack. TODO: check this more deterministically, "are we doing an x64 build?"
-  if builder.target.arch == 'x86':
-    binary.sources += ['sourcehook/sourcehook_hookmangen.cpp']
-  nodes = builder.Add(binary)
-  MMS.binaries += [nodes]
+    binary.sources += [
+      'metamod.cpp',
+      'metamod_console.cpp',
+      'metamod_oslink.cpp',
+      'metamod_plugins.cpp',
+      'metamod_util.cpp',
+      'provider/console.cpp',
+      'provider/provider_ep2.cpp',
+      'sourcehook/sourcehook.cpp',
+      'sourcehook/sourcehook_impl_chookidman.cpp',
+      'sourcehook/sourcehook_impl_chookmaninfo.cpp',
+      'sourcehook/sourcehook_impl_cproto.cpp',
+      'sourcehook/sourcehook_impl_cvfnptr.cpp',
+      'gamedll_bridge.cpp',
+      'vsp_bridge.cpp'
+    ]
+
+    # Source2 hack. TODO: check this more deterministically, "are we doing an x64 build?"
+    if arch == 'x86':
+      binary.sources += ['sourcehook/sourcehook_hookmangen.cpp']
+    nodes = builder.Add(binary)
+    MMS.binaries += [nodes]

--- a/core/metamod.cpp
+++ b/core/metamod.cpp
@@ -131,7 +131,7 @@ static ConVar *mm_basedir = NULL;
 static CreateInterfaceFn engine_factory = NULL;
 static CreateInterfaceFn physics_factory = NULL;
 static CreateInterfaceFn filesystem_factory = NULL;
-#if !defined( __amd64__ )
+#if !defined( _WIN64 ) && !defined( __amd64__ )
 static CHookManagerAutoGen g_SH_HookManagerAutoGen(&g_SourceHook);
 #endif
 static META_RES last_meta_res;
@@ -1004,7 +1004,7 @@ void *MetamodSource::MetaFactory(const char *iface, int *ret, PluginId *id)
 	}
 	else if (strcmp(iface, MMIFACE_SH_HOOKMANAUTOGEN) == 0)
 	{
-#if defined( __amd64__ )
+#if defined( _WIN64 ) || defined( __amd64__ )
 		if (ret)
 		{
 			*ret = META_IFACE_FAILED;

--- a/core/sourcehook/sh_memory.h
+++ b/core/sourcehook/sh_memory.h
@@ -129,13 +129,20 @@ namespace SourceHook
 #elif SH_SYS == SH_SYS_APPLE
 		vm_size_t ignoreSize;
 		vm_address_t vmaddr = (vm_address_t)addr;
+		memory_object_name_t obj;
+#if defined(__i386__)
 		vm_region_basic_info_data_t info;
 		vm_region_flavor_t flavor = VM_REGION_BASIC_INFO;
-		memory_object_name_t obj;
-
 		mach_msg_type_number_t count = VM_REGION_BASIC_INFO_COUNT;
 		kern_return_t kr = vm_region(mach_task_self(), &vmaddr, &ignoreSize, flavor,
 		                             (vm_region_info_t)&info, &count, &obj);
+#elif defined(__x86_64__)
+		vm_region_basic_info_data_64_t info;
+		vm_region_flavor_t flavor = VM_REGION_BASIC_INFO_64;
+		mach_msg_type_number_t count = VM_REGION_BASIC_INFO_COUNT_64;
+		kern_return_t kr = vm_region_64(mach_task_self(), &vmaddr, &ignoreSize, flavor,
+		                                (vm_region_info_64_t)&info, &count, &obj);
+#endif
 		if (kr != KERN_SUCCESS)
 			return false;
 		*bits = 0;

--- a/core/sourcehook/sh_memory.h
+++ b/core/sourcehook/sh_memory.h
@@ -340,7 +340,7 @@ namespace SourceHook
 
 			return false;
 #elif SH_SYS == SH_SYS_APPLE
-			struct sigaction sa, osa;
+			struct sigaction sa, osa, osa2;
 			sa.sa_sigaction = BadReadHandler;
 			sa.sa_flags = SA_SIGINFO | SA_RESTART;
 
@@ -350,6 +350,8 @@ namespace SourceHook
 				return false;
 
 			if (sigaction(SIGBUS, &sa, &osa) == -1)
+				return false;
+			if (sigaction(SIGSEGV, &sa, &osa) == -1)
 				return false;
 
 			volatile const char *p = reinterpret_cast<const char *>(addr);
@@ -361,6 +363,7 @@ namespace SourceHook
 			g_BadReadCalled = false;
 
 			sigaction(SIGBUS, &osa, NULL);
+			sigaction(SIGSEGV, &osa2, NULL);
 
 			return true;
 #elif SH_XP == SH_XP_WINAPI

--- a/core/sourcehook/sh_memory.h
+++ b/core/sourcehook/sh_memory.h
@@ -351,7 +351,7 @@ namespace SourceHook
 
 			if (sigaction(SIGBUS, &sa, &osa) == -1)
 				return false;
-			if (sigaction(SIGSEGV, &sa, &osa) == -1)
+			if (sigaction(SIGSEGV, &sa, &osa2) == -1)
 				return false;
 
 			volatile const char *p = reinterpret_cast<const char *>(addr);

--- a/core/sourcehook/test/AMBuilder
+++ b/core/sourcehook/test/AMBuilder
@@ -1,35 +1,42 @@
 # vim: set sts=2 ts=8 sw=2 tw=99 et ft=python: 
 import os
 
-binary = MMS.Program(builder, "test_sourcehook")
-binary.compiler.cxxincludes += [
-  os.path.join(builder.sourcePath, 'core', 'sourcehook'),
-]
+for arch in MMS.archs:
+  name = 'test_sourcehook'
+  binary = MMS.Program(builder, name, arch)
+  binary.compiler.cxxincludes += [
+    os.path.join(builder.sourcePath, 'core', 'sourcehook'),
+  ]
+  if binary.compiler.version >= 'clang-2.9' or binary.compiler.version >= 'apple-clang-3.0':
+    binary.compiler.cxxflags += ['-Wno-null-dereference']
+  if arch == 'x86_64':
+    binary.localFolder = name + ".x64"
 
-binary.sources += [
-  'main.cpp',
-  '../sourcehook.cpp',
-  '../sourcehook_hookmangen.cpp',
-  '../sourcehook_impl_chookmaninfo.cpp',
-  '../sourcehook_impl_chookidman.cpp',
-  '../sourcehook_impl_cproto.cpp',
-  '../sourcehook_impl_cvfnptr.cpp',
-  'test1.cpp',
-  'test2.cpp',
-  'test3.cpp',
-  'test4.cpp',
-  'testbail.cpp',
-  'testbail2.cpp',
-  'testhookmangen.cpp',
-  'testlist.cpp',
-  'testmanual.cpp',
-  'testmulti.cpp',
-  'testoddthunks.cpp',
-  'testrecall.cpp',
-  'testreentr.cpp',
-  'testref.cpp',
-  'testrefret.cpp',
-  'testvphooks.cpp',
-]
+  binary.sources += [
+    'main.cpp',
+    '../sourcehook.cpp',
+    '../sourcehook_impl_chookmaninfo.cpp',
+    '../sourcehook_impl_chookidman.cpp',
+    '../sourcehook_impl_cproto.cpp',
+    '../sourcehook_impl_cvfnptr.cpp',
+    'test1.cpp',
+    'test2.cpp',
+    'test3.cpp',
+    'test4.cpp',
+    'testbail.cpp',
+    'testbail2.cpp',
+    'testhookmangen.cpp',
+    'testlist.cpp',
+    'testmanual.cpp',
+    'testmulti.cpp',
+    'testoddthunks.cpp',
+    'testrecall.cpp',
+    'testreentr.cpp',
+    'testref.cpp',
+    'testrefret.cpp',
+    'testvphooks.cpp',
+  ]
+  if arch == 'x86':
+    binary.sources += ['../sourcehook_hookmangen.cpp']
 
-builder.Add(binary)
+  builder.Add(binary)

--- a/core/sourcehook/test/AMBuilder
+++ b/core/sourcehook/test/AMBuilder
@@ -9,8 +9,6 @@ for arch in MMS.archs:
   ]
   if binary.compiler.version >= 'clang-2.9' or binary.compiler.version >= 'apple-clang-3.0':
     binary.compiler.cxxflags += ['-Wno-null-dereference']
-  if arch == 'x86_64':
-    binary.localFolder = name + ".x64"
 
   binary.sources += [
     'main.cpp',

--- a/core/sourcehook/test/main.cpp
+++ b/core/sourcehook/test/main.cpp
@@ -78,7 +78,7 @@ int main(int argc, char *argv[])
 	DO_TEST(RefRet);
 	DO_TEST(VPHooks);
 	DO_TEST(CPageAlloc);
-#if !defined( _M_AMD64 ) && !defined( __amd64__ )		// TODO: Fix for 64-bit
+#if !defined( _M_AMD64 ) && !defined( __amd64__ ) && !defined(__x86_64__)	// TODO: Fix for 64-bit
 	DO_TEST(HookManGen);
 #endif
 	DO_TEST(OddThunks);
@@ -128,6 +128,7 @@ void Test_UnpausePlugin(SourceHook::ISourceHook *shptr, SourceHook::Plugin plug)
 	static_cast<SourceHook::Impl::CSourceHookImpl *>(shptr)->UnpausePlugin(plug);
 }
 
+#if !defined( _M_AMD64 ) && !defined( __amd64__ ) && !defined(__x86_64__)
 SourceHook::IHookManagerAutoGen *Test_HMAG_Factory(SourceHook::ISourceHook *shptr)
 {
 	return new SourceHook::Impl::CHookManagerAutoGen(shptr);
@@ -137,4 +138,5 @@ void Test_HMAG_Delete(SourceHook::IHookManagerAutoGen *ptr)
 {
 	delete static_cast<SourceHook::Impl::CHookManagerAutoGen*>(ptr);
 }
+#endif
 

--- a/core/sourcehook/test/testhookmangen.cpp
+++ b/core/sourcehook/test/testhookmangen.cpp
@@ -1093,7 +1093,7 @@ namespace
 	}
 }
 
-
+#if !defined( _M_AMD64 ) && !defined( __amd64__ ) && !defined(__x86_64__)
 bool TestHookManGen(std::string &error)
 {
 	GET_SHPTR(g_SHPtr);
@@ -1133,6 +1133,7 @@ bool TestHookManGen(std::string &error)
 
 	return true;
 }
+#endif
 
 bool TestCPageAlloc(std::string &error)
 {

--- a/core/sourcehook/test/testhookmangen.cpp
+++ b/core/sourcehook/test/testhookmangen.cpp
@@ -1,4 +1,5 @@
 #include <string>
+#include <cstdlib>
 #include "sourcehook.h"
 #include "sourcehook_test.h"
 #include "testevents.h"
@@ -1180,13 +1181,13 @@ bool TestCPageAlloc(std::string &error)
 		test4[i] = (char*) alloc.AllocIsolated(ps / 4);
 
 	// -> The difference is at least one page
-	CHECK_COND(static_cast<size_t>(abs(test4[1] - test4[0])) >= ps, "Part 3.1");
-	CHECK_COND(static_cast<size_t>(abs(test4[2] - test4[1])) >= ps, "Part 3.2");
-	CHECK_COND(static_cast<size_t>(abs(test4[3] - test4[2])) >= ps, "Part 3.3");
+	CHECK_COND(static_cast<size_t>(std::abs(test4[1] - test4[0])) >= ps, "Part 3.1");
+	CHECK_COND(static_cast<size_t>(std::abs(test4[2] - test4[1])) >= ps, "Part 3.2");
+	CHECK_COND(static_cast<size_t>(std::abs(test4[3] - test4[2])) >= ps, "Part 3.3");
 
-	CHECK_COND(static_cast<size_t>(abs(test4[5] - test4[4])) >= ps, "Part 3.4");
-	CHECK_COND(static_cast<size_t>(abs(test4[6] - test4[5])) >= ps, "Part 3.5");
-	CHECK_COND(static_cast<size_t>(abs(test4[7] - test4[6])) >= ps, "Part 3.6");
+	CHECK_COND(static_cast<size_t>(std::abs(test4[5] - test4[4])) >= ps, "Part 3.4");
+	CHECK_COND(static_cast<size_t>(std::abs(test4[6] - test4[5])) >= ps, "Part 3.5");
+	CHECK_COND(static_cast<size_t>(std::abs(test4[7] - test4[6])) >= ps, "Part 3.6");
 
 	// Thus i can set everything except for test4[2] to RE and still write to test4[2]
 

--- a/loader/AMBuilder
+++ b/loader/AMBuilder
@@ -1,8 +1,9 @@
 # vim: set ts=8 sts=2 sw=2 tw=99 et ft=python: 
 import os.path
 
-def configure_library(name, linux_defines):
-  binary = MMS.Library(builder, name)
+def configure_library(name, linux_defines, arch):
+  libname = name
+  binary = MMS.Library(builder, libname, arch)
   binary.compiler.cxxincludes += [os.path.join(builder.sourcePath, 'core', 'sourcehook')]
   binary.sources += [
     'loader.cpp',
@@ -10,6 +11,8 @@ def configure_library(name, linux_defines):
     'serverplugin.cpp',
     'utility.cpp',
   ]
+  if arch == 'x86_64':
+    binary.localFolder = name + ".x64"
 
   if builder.target.platform == 'linux':
     binary.compiler.defines += linux_defines
@@ -17,11 +20,11 @@ def configure_library(name, linux_defines):
   nodes = builder.Add(binary)
   MMS.binaries += [nodes]
 
-libname = 'server'
-if builder.target.platform == 'linux' and builder.target.arch == 'x86_64':
-  libname = 'libserver'
+for arch in MMS.archs:
+  if builder.target.platform == 'linux':
+    if arch == 'x86_64':
+      configure_library('libserver', ['LIB_PREFIX="lib"', 'LIB_SUFFIX=".so"'], arch)
+    elif arch == 'x86':
+      configure_library('server_i486', ['LIB_PREFIX=""', 'LIB_SUFFIX="_i486.so"'], arch)
 
-configure_library(libname, ['LIB_PREFIX="lib"', 'LIB_SUFFIX=".so"'])
-
-if builder.target.platform == 'linux' and builder.target.arch == 'x86':
-  configure_library('server_i486', ['LIB_PREFIX=""', 'LIB_SUFFIX="_i486.so"'])
+  configure_library('server', ['LIB_PREFIX="lib"', 'LIB_SUFFIX=".so"'], arch)

--- a/loader/AMBuilder
+++ b/loader/AMBuilder
@@ -20,7 +20,7 @@ def configure_library(name, linux_defines, arch):
 
 for arch in MMS.archs:
   if builder.target.platform == 'linux':
-    if arch == 'x86_64':
+    if arch == 'x64':
       configure_library('libserver', ['LIB_PREFIX="lib"', 'LIB_SUFFIX=".so"'], arch)
     elif arch == 'x86':
       configure_library('server_i486', ['LIB_PREFIX=""', 'LIB_SUFFIX="_i486.so"'], arch)

--- a/loader/AMBuilder
+++ b/loader/AMBuilder
@@ -11,8 +11,6 @@ def configure_library(name, linux_defines, arch):
     'serverplugin.cpp',
     'utility.cpp',
   ]
-  if arch == 'x86_64':
-    binary.localFolder = name + ".x64"
 
   if builder.target.platform == 'linux':
     binary.compiler.defines += linux_defines

--- a/sample_mm/Makefile
+++ b/sample_mm/Makefile
@@ -85,7 +85,11 @@ OS := $(shell uname -s)
 
 ifeq "$(OS)" "Darwin"
 	LIB_EXT = dylib
-	HL2LIB = $(HL2SDK)/lib/mac
+	ifeq "$(ENGINE)" "csgo"
+		HL2LIB = $(HL2SDK)/lib/osx64
+	else
+		HL2LIB = $(HL2SDK)/lib/mac
+	endif
 else
 	LIB_EXT = so
 	ifeq "$(ENGINE)" "original"
@@ -111,14 +115,25 @@ else
 	endif
 endif
 
+ifeq "$(OS)" "Darwin"
+	ifeq "$(ENGINE)" "csgo"
+		STATIC_SUFFIX = 
+		LIB_SUFFIX = .x64.$(LIB_EXT)
+	else
+		STATIC_SUFFIX = _i486
+	endif
+else
+	STATIC_SUFFIX = _i486
+endif
+
 CFLAGS += -DSE_EPISODEONE=1 -DSE_DARKMESSIAH=2 -DSE_ORANGEBOX=3 -DSE_BLOODYGOODTIME=4 -DSE_EYE=5 \
 	-DSE_CSS=6 -DSE_ORANGEBOXVALVE=7 -DSE_LEFT4DEAD=8 -DSE_LEFT4DEAD2=9 -DSE_ALIENSWARM=10 \
 	-DSE_PORTAL2=11 -DSE_CSGO=12
 
-LINK += $(HL2LIB)/tier1_i486.a $(LIB_PREFIX)vstdlib$(LIB_SUFFIX) $(LIB_PREFIX)tier0$(LIB_SUFFIX)
+LINK += $(HL2LIB)/tier1$(STATIC_SUFFIX).a $(LIB_PREFIX)vstdlib$(LIB_SUFFIX) $(LIB_PREFIX)tier0$(LIB_SUFFIX)
 
 ifeq "$(ENGINE)" "csgo"
-	LINK += $(HL2LIB)/interfaces_i486.a
+	LINK += $(HL2LIB)/interfaces$(STATIC_SUFFIX).a
 endif
 
 INCLUDE += -I. -I.. -I$(HL2PUB) -I$(HL2PUB)/engine -I$(HL2PUB)/mathlib -I$(HL2PUB)/vstdlib \
@@ -141,12 +156,19 @@ endif
 ifeq "$(OS)" "Darwin"
 	CPP = $(CPP_OSX)
 	LIB_EXT = dylib
-	CFLAGS += -DOSX -D_OSX
-	LINK += -dynamiclib -lstdc++ -mmacosx-version-min=10.5
+	CFLAGS += -DOSX -D_OSX -mmacosx-version-min=10.9
+	LINK += -dynamiclib -lc++ -mmacosx-version-min=10.9
+	ifeq "$(ENGINE)" "csgo"
+		CFLAGS += -m64 -DX64BITS -DPLATFORM_64BITS
+		LINK += -m64
+	else
+		CFLAGS += -m32
+		LINK += -m32
+	endif
 else
 	LIB_EXT = so
-	CFLAGS += -D_LINUX
-	LINK += -shared
+	CFLAGS += -D_LINUX -m32
+	LINK += -shared -m32
 endif
 
 IS_CLANG := $(shell $(CPP) --version | head -1 | grep clang > /dev/null && echo "1" || echo "0")
@@ -162,7 +184,7 @@ endif
 CFLAGS += -DPOSIX -Dstricmp=strcasecmp -D_stricmp=strcasecmp -D_strnicmp=strncasecmp \
 	-Dstrnicmp=strncasecmp -D_snprintf=snprintf -D_vsnprintf=vsnprintf -D_alloca=alloca \
 	-Dstrcmpi=strcasecmp -DCOMPILER_GCC -Wall -Wno-non-virtual-dtor -Wno-overloaded-virtual \
-	-Werror -fPIC -fno-exceptions -fno-rtti -msse -m32 -fno-strict-aliasing
+	-Werror -fPIC -fno-exceptions -fno-rtti -msse -fno-strict-aliasing
 
 # Clang || GCC >= 4
 ifeq "$(shell expr $(IS_CLANG) \| $(CPP_MAJOR) \>= 4)" "1"
@@ -171,7 +193,7 @@ endif
 
 # Clang >= 3 || GCC >= 4.7
 ifeq "$(shell expr $(IS_CLANG) \& $(CPP_MAJOR) \>= 3 \| $(CPP_MAJOR) \>= 4 \& $(CPP_MINOR) \>= 7)" "1"
-	CFLAGS += -Wno-delete-non-virtual-dtor
+	CFLAGS += -Wno-delete-non-virtual-dtor -Wno-unused-private-field -Wno-deprecated-register
 endif
 
 # OS is Linux and not using clang
@@ -198,7 +220,7 @@ check:
 	fi
 
 sample_mm: check $(OBJ_BIN)
-	$(CPP) $(INCLUDE) -m32 $(OBJ_BIN) $(LINK) -ldl -lm -o $(BIN_DIR)/$(BINARY)
+	$(CPP) $(INCLUDE) $(OBJ_BIN) $(LINK) -ldl -lm -o $(BIN_DIR)/$(BINARY)
 
 default: all
 

--- a/stub_mm/Makefile
+++ b/stub_mm/Makefile
@@ -26,7 +26,7 @@ OBJECTS = stub_mm.cpp
 ##############################################
 
 OPT_FLAGS = -O3 -funroll-loops -pipe
-GCC4_FLAGS = -fvisibility=hidden -fvisibility-inlines-hidden
+GCC4_FLAGS = -fvisibility=hidden -fvisibility-inlines-hidden -std=c++11
 DEBUG_FLAGS = -g -ggdb3 -D_DEBUG
 CPP = gcc
 CPP_OSX = clang
@@ -85,7 +85,11 @@ OS := $(shell uname -s)
 
 ifeq "$(OS)" "Darwin"
 	LIB_EXT = dylib
-	HL2LIB = $(HL2SDK)/lib/mac
+	ifeq "$(ENGINE)" "csgo"
+		HL2LIB = $(HL2SDK)/lib/osx64
+	else
+		HL2LIB = $(HL2SDK)/lib/mac
+	endif
 else
 	LIB_EXT = so
 	ifeq "$(ENGINE)" "original"
@@ -111,14 +115,24 @@ else
 	endif
 endif
 
+ifeq "$(OS)" "Darwin"
+	ifeq "$(ENGINE)" "csgo"
+		STATIC_SUFFIX = 
+	else
+		STATIC_SUFFIX = _i486
+	endif
+else
+	STATIC_SUFFIX = _i486
+endif
+
 CFLAGS += -DSE_EPISODEONE=1 -DSE_DARKMESSIAH=2 -DSE_ORANGEBOX=3 -DSE_BLOODYGOODTIME=4 -DSE_EYE=5 \
 	-DSE_CSS=6 -DSE_ORANGEBOXVALVE=7 -DSE_LEFT4DEAD=8 -DSE_LEFT4DEAD2=9 -DSE_ALIENSWARM=10 \
 	-DSE_PORTAL2=11 -DSE_CSGO=12
 
-LINK += $(HL2LIB)/tier1_i486.a $(LIB_PREFIX)vstdlib$(LIB_SUFFIX) $(LIB_PREFIX)tier0$(LIB_SUFFIX)
+LINK += $(HL2LIB)/tier1$(STATIC_SUFFIX).a $(LIB_PREFIX)vstdlib$(LIB_SUFFIX) $(LIB_PREFIX)tier0$(LIB_SUFFIX)
 
 ifeq "$(ENGINE)" "csgo"
-	LINK += $(HL2LIB)/interfaces_i486.a
+	LINK += $(HL2LIB)/interfaces$(STATIC_SUFFIX).a
 endif
 
 INCLUDE += -I. -I.. -I$(HL2PUB) -I$(HL2PUB)/engine -I$(HL2PUB)/mathlib -I$(HL2PUB)/vstdlib \
@@ -138,16 +152,22 @@ else
 	CFLAGS += $(OPT_FLAGS)
 endif
 
-
 ifeq "$(OS)" "Darwin"
 	CPP = $(CPP_OSX)
 	LIB_EXT = dylib
-	CFLAGS += -DOSX -D_OSX
-	LINK += -dynamiclib -lstdc++ -mmacosx-version-min=10.5
+	CFLAGS += -DOSX -D_OSX -mmacosx-version-min=10.9
+	LINK += -dynamiclib -lc++ -mmacosx-version-min=10.9
+	ifeq "$(ENGINE)" "csgo"
+		CFLAGS += -m64 -DX64BITS -DPLATFORM_64BITS
+		LINK += -m64
+	else
+		CFLAGS += -m32
+		LINK += -m32
+	endif
 else
 	LIB_EXT = so
-	CFLAGS += -D_LINUX
-	LINK += -shared
+	CFLAGS += -D_LINUX -m32
+	LINK += -shared -m32
 endif
 
 IS_CLANG := $(shell $(CPP) --version | head -1 | grep clang > /dev/null && echo "1" || echo "0")
@@ -163,7 +183,7 @@ endif
 CFLAGS += -DPOSIX -Dstricmp=strcasecmp -D_stricmp=strcasecmp -D_strnicmp=strncasecmp \
 	-Dstrnicmp=strncasecmp -D_snprintf=snprintf -D_vsnprintf=vsnprintf -D_alloca=alloca \
 	-Dstrcmpi=strcasecmp -DCOMPILER_GCC -Wall -Wno-non-virtual-dtor -Wno-overloaded-virtual \
-	-Werror -fPIC -fno-exceptions -fno-rtti -msse -m32 -fno-strict-aliasing
+	-Werror -fPIC -fno-exceptions -fno-rtti -msse -fno-strict-aliasing
 
 # Clang || GCC >= 4
 ifeq "$(shell expr $(IS_CLANG) \| $(CPP_MAJOR) \>= 4)" "1"
@@ -172,7 +192,7 @@ endif
 
 # Clang >= 3 || GCC >= 4.7
 ifeq "$(shell expr $(IS_CLANG) \& $(CPP_MAJOR) \>= 3 \| $(CPP_MAJOR) \>= 4 \& $(CPP_MINOR) \>= 7)" "1"
-	CFLAGS += -Wno-delete-non-virtual-dtor
+	CFLAGS += -Wno-delete-non-virtual-dtor -Wno-unused-private-field -Wno-deprecated-register
 endif
 
 # OS is Linux and not using clang
@@ -199,7 +219,7 @@ check:
 	fi
 
 stub_mm: check $(OBJ_BIN)
-	$(CPP) $(INCLUDE) -m32 $(OBJ_BIN) $(LINK) -ldl -lm -o $(BIN_DIR)/$(BINARY)
+	$(CPP) $(INCLUDE) $(OBJ_BIN) $(LINK) -ldl -lm -o $(BIN_DIR)/$(BINARY)
 
 default: all
 

--- a/support/buildbot/BreakpadSymbols
+++ b/support/buildbot/BreakpadSymbols
@@ -20,7 +20,7 @@ for cxx_task in cxx_tasks:
 	elif builder.target.platform == 'windows':
 		argv = ['dump_syms.exe', debug_file]
 
-	base_file = os.path.splitext(os.path.basename(debug_file))[0]
+	base_file = os.path.split(os.path.dirname(debug_file))[1]
 	symbol_file = base_file + '.breakpad'
 
 	argv = [sys.executable, UPLOAD_SCRIPT, symbol_file] + argv

--- a/support/buildbot/PackageScript
+++ b/support/buildbot/PackageScript
@@ -8,7 +8,7 @@ metamod_folder = builder.AddFolder(os.path.join('addons', 'metamod'))
 bin_folder = builder.AddFolder(os.path.join('addons', 'metamod', 'bin'))
 
 for arch in MMS.archs:
-	if arch == 'x86_64':
+	if arch == 'x64':
 		if builder.target.platform == 'windows':
 			bin64_folder = builder.AddFolder(os.path.join('addons', 'metamod', 'bin', 'win64'))
 			builder.AddCopy(os.path.join(builder.sourcePath, 'support', 'metamod_win64.vdf'), 

--- a/support/buildbot/PackageScript
+++ b/support/buildbot/PackageScript
@@ -7,13 +7,31 @@ addons_folder = builder.AddFolder('addons')
 metamod_folder = builder.AddFolder(os.path.join('addons', 'metamod'))
 bin_folder = builder.AddFolder(os.path.join('addons', 'metamod', 'bin'))
 
+for arch in MMS.archs:
+	if arch == 'x86_64':
+		if builder.target.platform == 'windows':
+			bin64_folder = builder.AddFolder(os.path.join('addons', 'metamod', 'bin', 'win64'))
+			builder.AddCopy(os.path.join(builder.sourcePath, 'support', 'metamod_win64.vdf'), 
+			                os.path.join('addons', 'metamod_x64.vdf'))
+		elif builder.target.platform == 'linux':
+			bin64_folder = builder.AddFolder(os.path.join('addons', 'metamod', 'bin', 'linux64'))
+			builder.AddCopy(os.path.join(builder.sourcePath, 'support', 'metamod_linux64.vdf'), 
+			                os.path.join('addons', 'metamod_x64.vdf'))
+		elif builder.target.platform == 'mac':
+			bin64_folder = builder.AddFolder(os.path.join('addons', 'metamod', 'bin', 'osx64'))
+			builder.AddCopy(os.path.join(builder.sourcePath, 'support', 'metamod_osx64.vdf'), 
+			                os.path.join('addons', 'metamod_x64.vdf'))
+
 builder.AddCopy(os.path.join(builder.sourcePath, 'support', 'metamod.vdf'), addons_folder)
 builder.AddCopy(os.path.join(builder.sourcePath, 'support', 'metaplugins.ini'), metamod_folder)
 builder.AddCopy(os.path.join(builder.sourcePath, 'support', 'README.txt'), metamod_folder)
 
 pdb_list = []
 for task in MMS.binaries:
-	builder.AddCopy(task.binary, bin_folder)
+	if '.x64' + os.sep in task.binary.path:
+		builder.AddCopy(task.binary, bin64_folder)
+	else:
+		builder.AddCopy(task.binary, bin_folder)
 
 	if task.debug:
 		pdb_list.append(task.debug)

--- a/support/buildbot/bootstrap.pl
+++ b/support/buildbot/bootstrap.pl
@@ -34,7 +34,6 @@ my @conf_argv = (
 	'--breakpad-dump',
 	'--no-color',
 	'--symbol-files'
-	'--target-arch=x86,x86_64'
 );
 
 if ($^O =~ /darwin/) {
@@ -43,6 +42,12 @@ if ($^O =~ /darwin/) {
 	push(@conf_argv, '--hl2sdk-root=/hgshare');
 } elsif ($^O =~ /MSWin/) {
 	push(@conf_argv, '--hl2sdk-root=H:\\');
+}
+
+if ($^O !~ /MSWin/) {
+	push(@conf_argv, '--target-arch=x86,x64');
+} else {
+	push(@conf_argv, '--target-arch=x86');
 }
 
 my $conf_args = join(' ', @conf_argv);

--- a/support/buildbot/bootstrap.pl
+++ b/support/buildbot/bootstrap.pl
@@ -34,6 +34,7 @@ my @conf_argv = (
 	'--breakpad-dump',
 	'--no-color',
 	'--symbol-files'
+	'--target-arch=x86,x86_64'
 );
 
 if ($^O =~ /darwin/) {

--- a/support/metamod_linux64.vdf
+++ b/support/metamod_linux64.vdf
@@ -1,0 +1,5 @@
+"Plugin"
+{
+	"file"	"addons/metamod/bin/linux64/server"
+}
+

--- a/support/metamod_osx64.vdf
+++ b/support/metamod_osx64.vdf
@@ -1,0 +1,5 @@
+"Plugin"
+{
+	"file"	"addons/metamod/bin/osx64/server"
+}
+

--- a/support/metamod_win64.vdf
+++ b/support/metamod_win64.vdf
@@ -1,0 +1,5 @@
+"Plugin"
+{
+	"file"	"addons/metamod/bin/win64/server"
+}
+

--- a/versionlib/AMBuildScript
+++ b/versionlib/AMBuildScript
@@ -9,8 +9,6 @@ for arch in MMS.archs:
   lib.sources += [
     'versionlib.cpp'
   ]
-  if arch == 'x86_64':
-    lib.localFolder = libname + '.x64'
 
   cmd = builder.Add(lib)
 

--- a/versionlib/AMBuildScript
+++ b/versionlib/AMBuildScript
@@ -1,13 +1,18 @@
 # vim: sts=2 ts=8 sw=2 tw=99 et ft=python:
 
-lib = builder.cxx.StaticLibrary("version")
-lib.compiler.defines.remove('MMS_USE_VERSIONLIB')
-lib.compiler.sourcedeps += MMS.generated_headers
-lib.sources += [
-  'versionlib.cpp'
-]
+rvalue = {}
+for arch in MMS.archs:
+  libname = 'version'
+  lib = MMS.StaticLibrary(builder, libname, arch)
+  lib.compiler.defines.remove('MMS_USE_VERSIONLIB')
+  lib.compiler.sourcedeps += MMS.generated_headers
+  lib.sources += [
+    'versionlib.cpp'
+  ]
+  if arch == 'x86_64':
+    lib.localFolder = libname + '.x64'
 
-cmd = builder.Add(lib)
+  cmd = builder.Add(lib)
 
-rvalue = cmd.binary
+  rvalue[arch] = cmd.binary
 


### PR DESCRIPTION
A lot of the work done for Source2 made this pretty easy. Lots of changes to AMBuild files here though to support building and packaging everything together.

Notable Changes:
- 64-bit binaries live in bin/linux64 or bin/osx64. Doing this allows gameinfo.txt loading to still work if it matters at all.
- Plugins with an .x64 suffix are loaded if no extension is specified
- Added metamod_x64.vdf to package to automatically load 64-bit version of Metamod.

Note: This requires an updated ambuild because it makes use of the ability to change the binary build folder (i.e. BinaryBuilder.localFolder).