### PR TITLE
Normalize paths when comparing. (fixes #37)

### DIFF
--- a/loader/utility.cpp
+++ b/loader/utility.cpp
@@ -225,6 +225,30 @@ mm_KeySplit(const char *str, char *buf1, size_t len1, char *buf2, size_t len2)
 bool
 mm_PathCmp(const char *path1, const char *path2)
 {
+#ifdef _WIN32
+	char szFullPath1[PLATFORM_MAX_PATH];
+	char szFullPath2[PLATFORM_MAX_PATH];
+	if (GetFullPathName(path1, sizeof(szFullPath1), szFullPath1, nullptr) != 0)
+	{
+		path1 = szFullPath1;
+	}
+	if (GetFullPathName(path2, sizeof(szFullPath2), szFullPath2, nullptr) != 0)
+	{
+		path2 = szFullPath2;
+	}
+#else
+	char szFullPath1[PATH_MAX + 1];
+	char szFullPath2[PATH_MAX + 1];
+	if (realpath(path1, szFullPath1))
+	{
+		path1 = szFullPath1;
+	}
+	if (realpath(path2, szFullPath2))
+	{
+		path2 = szFullPath2;
+	}
+#endif
+
 	size_t pos1 = 0, pos2 = 0;
 
 	while (true)


### PR DESCRIPTION
When resolving bin paths from gameinfo to platform-specific absolute paths, we end
up with ".." instances on x64, causing the paths being compared to look different. MM:S
then cannot differentiate it's server bin path from the game's server bin, causing us to
load ourselves as the server bin over and over again, causing a stack overflow.