### PR TITLE
Fix sh-tests for gcc-4.9+ 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,7 +80,7 @@ matrix:
           packages: ['clang-5.0', 'lib32stdc++6', 'lib32z1-dev', 'libc6-dev-i386', 'linux-libc-dev', 'g++-multilib']
       env: ['MATRIX_EVAL="CC=clang-5.0 && CXX=clang++-5.0"']
 
-   - os: linux
+    - os: linux
       sudo: false
       language: cpp
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,6 +80,15 @@ matrix:
           packages: ['clang-5.0', 'lib32stdc++6', 'lib32z1-dev', 'libc6-dev-i386', 'linux-libc-dev', 'g++-multilib']
       env: ['MATRIX_EVAL="CC=clang-5.0 && CXX=clang++-5.0"']
 
+   - os: linux
+      sudo: false
+      language: cpp
+      addons:
+        apt:
+          sources: ['ubuntu-toolchain-r-test']
+          packages: ['g++-6', 'g++-6-multilib', 'lib32stdc++6', 'lib32z1-dev', 'libc6-dev-i386', 'linux-libc-dev', 'g++-multilib']
+      env: ['MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"']
+
   allow_failures:
     - env: MATRIX_EVAL="CC=clang-3.7 && CXX=clang++-3.7"
     - env: MATRIX_EVAL="CC=clang-3.9 && CXX=clang++-3.9"

--- a/core/sourcehook/test/AMBuilder
+++ b/core/sourcehook/test/AMBuilder
@@ -7,7 +7,7 @@ for arch in MMS.archs:
   binary.compiler.cxxincludes += [
     os.path.join(builder.sourcePath, 'core', 'sourcehook'),
   ]
-  if binary.compiler.version >= 'gcc-4.9'
+  if binary.compiler.version >= 'gcc-4.9':
     binary.compiler.cxxflags += ['-fno-devirtualize']
   if binary.compiler.version >= 'clang-2.9' or binary.compiler.version >= 'apple-clang-3.0':
     binary.compiler.cxxflags += ['-Wno-null-dereference']

--- a/core/sourcehook/test/AMBuilder
+++ b/core/sourcehook/test/AMBuilder
@@ -7,6 +7,8 @@ for arch in MMS.archs:
   binary.compiler.cxxincludes += [
     os.path.join(builder.sourcePath, 'core', 'sourcehook'),
   ]
+  if binary.compiler.version >= 'gcc-4.9'
+    binary.compiler.cxxflags += ['-fno-devirtualize']
   if binary.compiler.version >= 'clang-2.9' or binary.compiler.version >= 'apple-clang-3.0':
     binary.compiler.cxxflags += ['-Wno-null-dereference']
 

--- a/pushbuild.txt
+++ b/pushbuild.txt
@@ -35,3 +35,4 @@ dvander is one million ladies tall today...
 Your tier1 tower is under attack..
 Christmas!
 is Skinny Pete any relation to Sneaky Pete???
+where Travis?


### PR DESCRIPTION
GCC-4.9 went to great efforts to de-virtualize virtualized calls to greatly improve performance when the compiler was able to guarantee that there were no other members making virtualized calls. Unfortunately for us, SH was not a considered a computable use-case which results in the O2+ by default breakage using GCC-4.9+. This PR turns off that new optimization for tests.