### PR TITLE
Fix XCode 10+ build issues

### DIFF
--- a/AMBuildScript
+++ b/AMBuildScript
@@ -202,7 +202,7 @@ class MMSConfig(object):
         cxx.cflags += ['-mfpmath=sse']
       if cxx.family == 'clang':
         cxx.cxxflags += ['-Wno-implicit-exception-spec-mismatch']
-        if cxx.version >= 'clang-3.9':
+        if cxx.version >= 'clang-3.9' or cxx.version >= 'apple-clang-10.0':
           cxx.cxxflags += ['-Wno-expansion-to-defined']
         if cxx.version >= 'clang-3.6' or cxx.version >= 'apple-clang-7.0':
           cxx.cxxflags += ['-Wno-inconsistent-missing-override']

--- a/AMBuildScript
+++ b/AMBuildScript
@@ -275,9 +275,19 @@ class MMSConfig(object):
         cxx.linkflags += ['-lgcc_eh']
     elif builder.target.platform == 'mac':
       cxx.defines += ['OSX', '_OSX', 'POSIX']
-      cxx.cflags += ['-mmacosx-version-min=10.5']
+
+      if cxx.version >= 'apple-clang-10.0':
+        cxx.cflags += ['-mmacosx-version-min=10.9', '-stdlib=libc++']
+        cxx.linkflags += [
+          '-mmacosx-version-min=10.9',
+        ]
+      else:
+        cxx.cflags += ['-mmacosx-version-min=10.5']
+        cxx.linkflags += [
+          '-mmacosx-version-min=10.5',
+        ]
+
       cxx.linkflags += [
-        '-mmacosx-version-min=10.5',
         '-lc++',
       ]
     elif builder.target.platform == 'windows':


### PR DESCRIPTION
Fix #54 

* Treat `apple-clang-10.0` and above as `clang-3.9` and above for `-Wno-expansion-to-defined`.
* Use libc++ instead of no-longer supported libstdc++ on XCode 10 and above.