### PR TITLE
Fix xcode 10 builds

### DIFF
--- a/AMBuildScript
+++ b/AMBuildScript
@@ -274,12 +274,14 @@ class MMSConfig(object):
       elif cxx.family == 'clang':
         cxx.linkflags += ['-lgcc_eh']
     elif builder.target.platform == 'mac':
+      if cxx.version < 'apple-clang-10.0':
+        cxx.cflags += ['-mmacosx-version-min=10.5']
+        cxx.linkflags += [
+          '-mmacosx-version-min=10.5',
+          '-lc++',
+        ]
+
       cxx.defines += ['OSX', '_OSX', 'POSIX']
-      cxx.cflags += ['-mmacosx-version-min=10.5']
-      cxx.linkflags += [
-        '-mmacosx-version-min=10.5',
-        '-lc++',
-      ]
     elif builder.target.platform == 'windows':
       cxx.defines += ['WIN32', '_WINDOWS']
 


### PR DESCRIPTION
This prevents complete build failure on newer xcode installations. It does not, however, fix all the errors  (`-Werror`) that the hl2sdks give on macro expansions. 

```
In file included from /Users/michaelflaherty/Desktop/mmstst/metamod-source/core/provider/provider_ep2.cpp:30:
In file included from /Users/michaelflaherty/Desktop/mmstst/hl2sdk-css/public/tier1/convar.h:21:
In file included from /Users/michaelflaherty/Desktop/mmstst/hl2sdk-css/public/tier1/utlvector.h:23:
In file included from /Users/michaelflaherty/Desktop/mmstst/hl2sdk-css/public/tier1/utlmemory.h:20:
In file included from /Users/michaelflaherty/Desktop/mmstst/hl2sdk-css/public/mathlib/mathlib.h:12:
/Users/michaelflaherty/Desktop/mmstst/hl2sdk-css/public/mathlib/vector.h:224:5: error: macro expansion producing 'defined' has undefined behavior [-Werror,-Wexpansion-to-defined]
#if USE_M64S
    ^
/Users/michaelflaherty/Desktop/mmstst/hl2sdk-css/public/mathlib/vector.h:207:23: note: expanded from macro 'USE_M64S'
#define USE_M64S ( ( !defined( _X360 ) ) && ( ! defined( _LINUX) ) )
                      ^
/Users/michaelflaherty/Desktop/mmstst/hl2sdk-css/public/mathlib/vector.h:224:5: error: macro expansion producing 'defined' has undefined behavior [-Werror,-Wexpansion-to-defined]
/Users/michaelflaherty/Desktop/mmstst/hl2sdk-css/public/mathlib/vector.h:207:49: note: expanded from macro 'USE_M64S'
#define USE_M64S ( ( !defined( _X360 ) ) && ( ! defined( _LINUX) ) )
                                                ^
/Users/michaelflaherty/Desktop/mmstst/hl2sdk-css/public/mathlib/vector.h:281:5: error: macro expansion producing 'defined' has undefined behavior [-Werror,-Wexpansion-to-defined]
#if USE_M64S
    ^
/Users/michaelflaherty/Desktop/mmstst/hl2sdk-css/public/mathlib/vector.h:207:23: note: expanded from macro 'USE_M64S'
#define USE_M64S ( ( !defined( _X360 ) ) && ( ! defined( _LINUX) ) )
                      ^
/Users/michaelflaherty/Desktop/mmstst/hl2sdk-css/public/mathlib/vector.h:281:5: error: macro expansion producing 'defined' has undefined behavior [-Werror,-Wexpansion-to-defined]
/Users/michaelflaherty/Desktop/mmstst/hl2sdk-css/public/mathlib/vector.h:207:49: note: expanded from macro 'USE_M64S'
#define USE_M64S ( ( !defined( _X360 ) ) && ( ! defined( _LINUX) ) )
```

We either edit the sdks to prevent the build error, or pass `-Wexpansion-to-defined` on these builds. @psychonic ?



Fixes #54 