### PR TITLE
Enable Insurgency and Blade Symphony x64 builds

### DIFF
--- a/AMBuildScript
+++ b/AMBuildScript
@@ -37,6 +37,15 @@ Source2 = {
   'windows': ['x86', 'x86_64'],
   'linux': ['x86_64'],
 }
+Insurgency = {
+  'windows': ['x86', 'x86_64'],
+  'linux': ['x86'],
+  'mac': ['x86', 'x86_64'],
+}
+Blade = {
+  'windows': ['x86', 'x86_64'],
+  'linux': ['x86_64']
+}
 
 PossibleSDKs = {
   'episode1':  SDK('HL2SDK', '2.ep1', '1', 'EPISODEONE', WinLinux, 'episode1'),
@@ -56,8 +65,8 @@ PossibleSDKs = {
   'csgo': SDK('HL2SDKCSGO', '2.csgo', '21', 'CSGO', CSGO, 'csgo'),
   'dota': SDK('HL2SDKDOTA', '2.dota', '22', 'DOTA', [], 'dota'),
   'portal2':  SDK('HL2SDKPORTAL2', '2.portal2', '17', 'PORTAL2', [], 'portal2'),
-  'blade':  SDK('HL2SDKBLADE', '2.blade', '18', 'BLADE', WinOnly, 'blade'),
-  'insurgency':  SDK('HL2SDKINSURGENCY', '2.insurgency', '19', 'INSURGENCY', WinLinuxMac, 'insurgency'),
+  'blade':  SDK('HL2SDKBLADE', '2.blade', '18', 'BLADE', Blade, 'blade'),
+  'insurgency':  SDK('HL2SDKINSURGENCY', '2.insurgency', '19', 'INSURGENCY', Insurgency, 'insurgency'),
   'doi':  SDK('HL2SDKDOI', '2.doi', '20', 'DOI', WinLinuxMac, 'doi'),
   'contagion':  SDK('HL2SDKCONTAGION', '2.contagion', '14', 'CONTAGION', WinOnly, 'contagion'),
   'bms':  SDK('HL2SDKBMS', '2.bms', '10', 'BMS', WinLinux, 'bms'),

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ install:
 - cmd: set PATH=C:\Python38;C:\Python38\Scripts;%PATH%
 - cmd: git pull
 - cmd: cd ..
-- ps: metamod-source/support/checkout-deps.ps1 -SDKs csgo,l4d2,tf2,episode1,insurgency
+- ps: metamod-source/support/checkout-deps.ps1 -SDKs ($env:SDKS -split ',')
 - cmd: cd metamod-source
 build_script:
 - cmd: mkdir build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,96 +1,18 @@
 version: 1.0.{build}
 image: Visual Studio 2015
 clone_folder: c:\projects\metamod-source
+clone_depth: 1
+environment:
+  SDKS: csgo,l4d2,tf2,episode1,insurgency
 install:
-- ps: >-
-    Function Checkout-Repo($name, $branch, $repo, $origin)
-
-    {
-        if (-not (Test-Path $name -PathType Container))
-        {
-            git clone $repo -b $branch $name 2>&1 | Write-Host
-            if ($origin)
-            {
-                cd $name
-                git remote rm origin 2>&1 | Write-Host
-                git remote add origin $origin 2>&1 | Write-Host
-                cd ..
-            }
-        }
-        else
-        {
-            cd $name
-            git checkout $branch 2>&1 | Write-Host
-            git pull origin $branch 2>&1 | Write-Host
-            cd ..
-        }
-    }
-
-
-    Set-Location $env:APPVEYOR_BUILD_FOLDER
-
-    [System.Environment]::CurrentDirectory = Get-Location
-
-
-    cd ..
-
-    [System.Environment]::CurrentDirectory = Get-Location
-
-
-    if (-not (Test-Path "metamod-source" -PathType Container))
-
-    {
-        Write-Error "Could not find a MetaMod:Source repository; make sure you aren't running this script inside it."
-        Exit 1
-    }
-
-
-    $SDKS = @( "csgo", "l4d2", "tf2", "episode1", "insurgency" )
-
-    if (-not (Test-Path "hl2sdk-proxy-repo" -PathType Container))
-
-    {
-        git clone --mirror https://github.com/alliedmodders/hl2sdk hl2sdk-proxy-repo 2>&1 | Write-Host
-    }
-
-    else
-
-    {
-        cd hl2sdk-proxy-repo
-        git fetch 2>&1 | Write-Host
-        cd ..
-    }
-
-
-    $SDKS | % {
-        Checkout-Repo "hl2sdk-$_" $_ "hl2sdk-proxy-repo" "https://github.com/alliedmodders/hl2sdk"
-    }
-
-
-    Checkout-Repo "ambuild" "master" "https://github.com/alliedmodders/ambuild"
-
-    cd ambuild
-
-    & c:\python27\python.exe setup.py install
-
-
-    [System.Environment]::CurrentDirectory = "c:\projects\"
-
-    Set-Location "c:\projects\"
-
-
-    #Checkout-Repo "amtl" "master" "https://github.com/alliedmodders/amtl"
-
-
-    Set-Location $env:APPVEYOR_BUILD_FOLDER
-
-    [System.Environment]::CurrentDirectory = Get-Location
+# https://www.appveyor.com/docs/windows-images-software/#python
+- cmd: set PATH=C:\Python38;C:\Python38\Scripts;%PATH%
+- cmd: git pull
+- cmd: cd ..
+- ps: metamod-source/support/checkout-deps.ps1 -SDKs $env:SDKS
+- cmd: cd metamod-source
 build_script:
-- cmd: >-
-    "%VS140COMNTOOLS%\vsvars32.bat"
-
-    mkdir opt32 && cd opt32
-
-    C:\python27\python.exe ..\configure.py --enable-optimize --sdks=csgo,l4d2,tf2,episode1,insurgency
-
-    C:\python27\Scripts\ambuild
+- cmd: mkdir build
+- cmd: cd build
+- cmd: python ../configure.py --enable-optimize --sdks=%SDKS% --targets=x86,x86_64
+- cmd: ambuild

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,7 +45,7 @@ install:
     }
 
 
-    $SDKS = @( "csgo", "l4d2", "tf2", "episode1" )
+    $SDKS = @( "csgo", "l4d2", "tf2", "episode1", "insurgency" )
 
     if (-not (Test-Path "hl2sdk-proxy-repo" -PathType Container))
 
@@ -91,6 +91,6 @@ build_script:
 
     mkdir opt32 && cd opt32
 
-    C:\python27\python.exe ..\configure.py --enable-optimize --sdks=csgo,l4d2,tf2,episode1
+    C:\python27\python.exe ..\configure.py --enable-optimize --sdks=csgo,l4d2,tf2,episode1,insurgency
 
     C:\python27\Scripts\ambuild

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ install:
 - cmd: set PATH=C:\Python38;C:\Python38\Scripts;%PATH%
 - cmd: git pull
 - cmd: cd ..
-- ps: metamod-source/support/checkout-deps.ps1 -SDKs $env:SDKS
+- ps: metamod-source/support/checkout-deps.ps1 -SDKs csgo,l4d2,tf2,episode1,insurgency
 - cmd: cd metamod-source
 build_script:
 - cmd: mkdir build

--- a/support/checkout-deps.ps1
+++ b/support/checkout-deps.ps1
@@ -1,0 +1,133 @@
+﻿<#
+.SYNOPSIS
+    Downloads dependencies for compiling MetaMod:Source.
+.PARAMETER SDKs
+    List of HL2SDK branch names to downloads.
+#>
+
+[CmdletBinding()]
+param(
+    [string[]]$SDKs = @(
+        'csgo',
+        'hl2dm',
+        'nucleardawn',
+        'l4d2',
+        'dods',
+        'l4d',
+        'css',
+        'tf2',
+        'insurgency',
+        'sdk2013',
+        'dota',
+        'orangebox',
+        'blade',
+        'episode1',
+        'bms',
+        'darkm',
+        'swarm',
+        'bgt',
+        'eye',
+        'contagion',
+        'doi'
+        )
+)
+
+Function Get-Repository
+{
+    param(
+        [Parameter(Mandatory=$true)][string]$Name,
+        [Parameter(Mandatory=$true)][string]$Branch,
+        [Parameter(Mandatory=$true)][string]$Repo,
+        [string]$Origin
+    )
+
+    If (-not (Test-Path $Name -PathType Container))
+    {
+        & git clone $Repo -b $Branch $Name 2>&1 | Write-Host
+        If ($Origin)
+        {
+            Set-Location $Name
+            & git remote set-url origin $Origin 2>&1 | Write-Host
+            Set-Location ..
+        }
+    }
+    Else
+    {
+        Set-Location $Name
+        If ($Origin)
+        {
+            & git remote set-url origin ..\$Repo 2>&1 | Write-Host
+        }
+        & git checkout $Branch 2>&1 | Write-Host
+        & git pull origin $Branch 2>&1 | Write-Host
+        If ($Origin)
+        {
+            & git remote set-url origin $Origin 2>&1 | Write-Host
+        }
+        Set-Location ..
+    }
+}
+
+if (-not (Test-Path "metamod-source" -PathType Container))
+{
+    Write-Error "Could not find a MetaMod:Source repository; make sure you aren't running this script inside it."
+    Exit 1
+}
+
+if (-not (Test-Path "hl2sdk-proxy-repo" -PathType Container))
+{
+    & git clone --mirror https://github.com/alliedmodders/hl2sdk hl2sdk-proxy-repo 2>&1 | Write-Host
+}
+else
+{
+    Set-Location hl2sdk-proxy-repo
+    & git fetch 2>&1 | Write-Host
+    Set-Location ..
+}
+
+$SDKS | ForEach-Object {
+    Get-Repository -Name "hl2sdk-$_" -Branch $_ -Repo "hl2sdk-proxy-repo" "https://github.com/alliedmodders/hl2sdk.git"
+}
+
+# Find a suitable installation of Python
+$PYTHON_CMD = Get-Command 'python' -ErrorAction SilentlyContinue
+if ($NULL -eq $PYTHON_CMD)
+{
+    $PYTHON_CMD = Get-Command 'python3' -ErrorAction SilentlyContinue
+    if ($NULL -eq $PYTHON_CMD)
+    {
+        $PYTHON_CMD = Get-Command 'py' -ErrorAction SilentlyContinue
+        if ($NULL -eq $PYTHON_CMD)
+        {
+            Write-Error 'No suitable installation of Python detected'
+            Exit 1
+        }
+    }
+}
+
+$PYTHON_CMD = $PYTHON_CMD.Source # Convert the result into a string path.
+
+& $PYTHON_CMD -c 'import ambuild2' 2>&1 1>$NULL
+if ($LastExitCode -eq 1)
+{
+    Write-Host -ForegroundColor Red "AMBuild is required to build MetaMod:Source"
+
+    # Ensure PIP is installed, otherwise, install it.
+    & $PYTHON_CMD -m pip --version 2>&1 1>$NULL # We use PIP's '--version' as it's the least verbose.
+    if ($LastExitCode -eq 1) {
+        Write-Host -ForegroundColor Red 'The detected Python installation does not have PIP'
+        Write-Host 'Installing the latest version of PIP available (VIA "get-pip.py")'
+
+        $GET_PIP = Join-Path $(Resolve-Path './') 'get-pip.py'
+        Invoke-WebRequest -Uri "https://bootstrap.pypa.io/get-pip.py" -OutFile $GET_PIP
+
+        & $PYTHON_CMD $GET_PIP
+        if ($LastExitCode -eq 1) {
+            Write-Error 'Installation of PIP has failed'
+            Exit 1
+        }
+    }
+
+    Get-Repository -Name "ambuild" -Branch "master" -Repo "https://github.com/alliedmodders/ambuild.git"
+    & $PYTHON_CMD -m pip install ./ambuild
+}


### PR DESCRIPTION
The HL2SDKs were updated to support compilation and linking on x64 beforehand. #67 allowed to load MMS on Blade Symphony Win64. AMBuild 2.2 allowed to build for multiple architectures in one build script on Windows.

This should be enough to ship some x64 builds.

Fixes #76
Fixes #47
Fixes #40