### PR TITLE
Add support for IServerPluginCallbacks v3 and v4

### DIFF
--- a/loader/serverplugin.cpp
+++ b/loader/serverplugin.cpp
@@ -283,6 +283,29 @@ public:
 										  const char *pCvarValue)
 	{
 	}
+	virtual void OnEdictAllocated(edict_t *edict)
+	{
+	}
+	virtual void OnEdictFreed(const edict_t *edict)
+	{
+	}
+	virtual bool BNetworkCryptKeyCheckRequired(unsigned int unFromIP,
+											   unsigned short usFromPort,
+											   unsigned int unAccountIdProvidedByClient,
+											   bool bClientWantsToUseCryptKey)
+	{
+		return false;
+	}
+	virtual bool BNetworkCryptKeyValidate(unsigned int unFromIP,
+										  unsigned short usFromPort,
+										  unsigned int unAccountIdProvidedByClient,
+										  int nEncryptionKeyIndexFromClient,
+										  int numEncryptedBytesFromClient,
+										  unsigned char *pbEncryptedBufferFromClient,
+										  unsigned char *pbPlainTextKeyForNetchan)
+	{
+		return false;
+	}
 	void PrepForLoad(unsigned int version)
 	{
 		vsp_version = version;
@@ -297,8 +320,8 @@ void *mm_GetVspCallbacks(unsigned int version)
 	if (vsp_bridge != NULL)
 		return NULL;
 
-	/* Only support versions 1 or 2 right now */
-	if (version > 2)
+	/* Only support versions 1 to 4 right now */
+	if (version > 4)
 		return NULL;
 
 	mm_vsp_callbacks.PrepForLoad(version);


### PR DESCRIPTION
This PR adds support for IServerPluginCallbacks v3 and v4. Those added functions can then be hooked from within SourceMod.

Let me know if this creates binary incompatibilities with servers only supporting v1 and v2. As of my understanding, it should be fine though as the additional entries in the vtable would simply be ignored.

More on why this might needed: https://developer.valvesoftware.com/wiki/Counter-Strike:_Global_Offensive_Network_Channel_Encryption