### PR TITLE
Make TF2 detection more strict

### DIFF
--- a/loader/loader.cpp
+++ b/loader/loader.cpp
@@ -412,8 +412,7 @@ mm_DetermineBackend(QueryValveInterface engineFactory, QueryValveInterface serve
 					{
 						return MMBackend_CSS;
 					}
-					else if (strcmp(game_name, "tf") == 0
-						|| (addr = mm_FindPattern(lib, "DT_TFPlayerResource", sizeof("DT_TFPlayerResource") - 1)))
+					else if (strcmp(game_name, "tf") == 0)
 					{
 						return MMBackend_TF2;
 					}


### PR DESCRIPTION
This PR aims mostly at stopping metamod from recognising other games as "tf2" when they really shouldn't be. Like tf2classic that is a mod of sdk 2013.

@psychonic also suggested removing this check https://forums.alliedmods.net/showpost.php?p=2433735&postcount=11