### PR TITLE
Split PVKII into its own engine branch

### DIFF
--- a/AMBuildScript
+++ b/AMBuildScript
@@ -76,6 +76,7 @@ PossibleSDKs = {
   'contagion':  SDK('HL2SDKCONTAGION', '2.contagion', '14', 'CONTAGION', WinOnly, 'contagion'),
   'bms':  SDK('HL2SDKBMS', '2.bms', '10', 'BMS', WinLinux, 'bms'),
   'mock': SDK('HL2SDK-MOCK', '2.mock', '999', 'MOCK', Mock, 'mock'),
+  'pvkii': SDK('HL2SDKPVKII', '2.pvkii', '23', 'PVKII', WinLinux, 'pvkii'),
 }
 
 def ResolveEnvPath(env, folder):
@@ -365,7 +366,7 @@ class MMSConfig(object):
 
     compiler.defines += ['SOURCE_ENGINE=' + sdk.code]
 
-    if sdk.name in ['sdk2013', 'bms'] and compiler.like('gcc'):
+    if sdk.name in ['sdk2013', 'bms', 'pvkii'] and compiler.like('gcc'):
       # The 2013 SDK already has these in public/tier0/basetypes.h
       compiler.defines.remove('stricmp=strcasecmp')
       compiler.defines.remove('_stricmp=strcasecmp')
@@ -387,7 +388,7 @@ class MMSConfig(object):
     if compiler.target.arch == 'x86_64':
       compiler.defines += ['X64BITS', 'PLATFORM_64BITS']
 
-    if sdk.name in ['css', 'hl2dm', 'dods', 'sdk2013', 'bms', 'tf2', 'l4d', 'nucleardawn', 'l4d2', 'dota']:
+    if sdk.name in ['css', 'hl2dm', 'dods', 'sdk2013', 'bms', 'tf2', 'l4d', 'nucleardawn', 'l4d2', 'dota', 'pvkii']:
       if compiler.target.platform in ['linux', 'mac']:
         compiler.defines += ['NO_HOOK_MALLOC', 'NO_MALLOC_OVERRIDE']
 
@@ -446,7 +447,7 @@ class MMSConfig(object):
     if compiler.target.platform == 'linux':
       if sdk.name == 'episode1':
         lib_folder = os.path.join(sdk.path, 'linux_sdk')
-      elif sdk.name in ['sdk2013', 'bms']:
+      elif sdk.name in ['sdk2013', 'bms', 'pvkii']:
         lib_folder = os.path.join(sdk.path, 'lib', 'public', 'linux32')
       elif compiler.target.arch == 'x86_64':
         lib_folder = os.path.join(sdk.path, 'lib', 'linux64')
@@ -461,7 +462,7 @@ class MMSConfig(object):
         lib_folder = os.path.join(sdk.path, 'lib', 'mac')
 
     if compiler.target.platform in ['linux', 'mac']:
-      if sdk.name in ['sdk2013', 'bms'] or compiler.target.arch == 'x86_64':
+      if sdk.name in ['sdk2013', 'bms', 'pvkii'] or compiler.target.arch == 'x86_64':
         tier1 = os.path.join(lib_folder, 'tier1.a')
       else:
         tier1 = os.path.join(lib_folder, 'tier1_i486.a')
@@ -488,7 +489,7 @@ class MMSConfig(object):
         dynamic_libs = ['libtier0_srv.so', 'libvstdlib_srv.so']
       elif compiler.target.arch == 'x86_64' and sdk.name in ['csgo', 'mock']:
         dynamic_libs = ['libtier0_client.so', 'libvstdlib_client.so']
-      elif sdk.name in ['l4d', 'blade', 'insurgency', 'doi', 'csgo', 'dota']:
+      elif sdk.name in ['l4d', 'blade', 'insurgency', 'doi', 'csgo', 'dota', 'pvkii']:
         dynamic_libs = ['libtier0.so', 'libvstdlib.so']
       else:
         dynamic_libs = ['tier0_i486.so', 'vstdlib_i486.so']

--- a/core/ISmmPluginExt.h
+++ b/core/ISmmPluginExt.h
@@ -61,6 +61,7 @@
 #define SOURCE_ENGINE_BMS				23				/**< Black Mesa Multiplayer */
 #define SOURCE_ENGINE_DOI				24				/**< Day of Infamy */
 #define SOURCE_ENGINE_MOCK				25				/**< Mock source engine */
+#define SOURCE_ENGINE_PVKII				26				/**< Pirates, Vikings, and Knights II */
 
 #define METAMOD_PLAPI_VERSION			16				/**< Version of this header file */
 #define METAMOD_PLAPI_NAME				"ISmmPlugin"	/**< Name of the plugin interface */

--- a/core/provider/provider_ep2.cpp
+++ b/core/provider/provider_ep2.cpp
@@ -677,6 +677,8 @@ const char *BaseProvider::GetEngineDescription() const
 	}
 #elif SOURCE_ENGINE == SE_MOCK
 	return "Mock";
+#elif SOURCE_ENGINE == SE_PVKII
+	return "Pirates, Vikings, and Knights II";
 #else
 #error "SOURCE_ENGINE not defined to a known value"
 #endif

--- a/core/provider/provider_ep2.cpp
+++ b/core/provider/provider_ep2.cpp
@@ -132,7 +132,7 @@ void BaseProvider::ConsolePrint(const char *str)
 void BaseProvider::Notify_DLLInit_Pre(CreateInterfaceFn engineFactory, 
 									  CreateInterfaceFn serverFactory)
 {
-#if SOURCE_ENGINE == SE_TF2 || SOURCE_ENGINE == SE_CSS || SOURCE_ENGINE == SE_DODS || SOURCE_ENGINE == SE_HL2DM || SOURCE_ENGINE == SE_SDK2013
+#if SOURCE_ENGINE == SE_TF2 || SOURCE_ENGINE == SE_CSS || SOURCE_ENGINE == SE_DODS || SOURCE_ENGINE == SE_HL2DM || SOURCE_ENGINE == SE_SDK2013 || SOURCE_ENGINE == SE_PVKII
 	// Shim to avoid hooking shims
 	engine = (IVEngineServer *)((engineFactory)("VEngineServer023", NULL));
 	if (!engine)
@@ -542,6 +542,8 @@ int BaseProvider::DetermineSourceEngine()
 	return g_bOriginalEngine ? SOURCE_ENGINE_ORIGINAL : SOURCE_ENGINE_EPISODEONE;
 #elif SOURCE_ENGINE == SE_MOCK
 	return SOURCE_ENGINE_MOCK;
+#elif SOURCE_ENGINE == SE_PVKII
+	return SOURCE_ENGINE_PVKII
 #else
 #error "SOURCE_ENGINE not defined to a known value"
 #endif

--- a/core/provider/provider_ep2.cpp
+++ b/core/provider/provider_ep2.cpp
@@ -543,7 +543,7 @@ int BaseProvider::DetermineSourceEngine()
 #elif SOURCE_ENGINE == SE_MOCK
 	return SOURCE_ENGINE_MOCK;
 #elif SOURCE_ENGINE == SE_PVKII
-	return SOURCE_ENGINE_PVKII
+	return SOURCE_ENGINE_PVKII;
 #else
 #error "SOURCE_ENGINE not defined to a known value"
 #endif

--- a/loader/loader.cpp
+++ b/loader/loader.cpp
@@ -92,6 +92,7 @@ static const char *backend_names[] =
 	"2.bms",
 	"2.doi",
 	"2.mock",
+	"2.pvkii"
 };
 
 #if defined _WIN32
@@ -425,6 +426,10 @@ mm_DetermineBackend(QueryValveInterface engineFactory, QueryValveInterface serve
 					else if (strcmp(game_name, "hl2mp") == 0)
 					{
 						return MMBackend_HL2DM;
+					}
+					else if (strcmp(game_name, "pvkii") == 0)
+					{
+						return MMBackend_PVKII;
 					}
 					else if (strcmp(game_name, ".") == 0 && engineFactory("MOCK_ENGINE", NULL))
 					{

--- a/loader/loader.h
+++ b/loader/loader.h
@@ -103,8 +103,9 @@ enum MetamodBackend
 	MMBackend_Contagion,
 	MMBackend_BMS,
 	MMBackend_DOI,
-
 	MMBackend_Mock,
+	
+	MMBackend_PVKII,
 	MMBackend_UNKNOWN
 };
 

--- a/support/checkout-deps.ps1
+++ b/support/checkout-deps.ps1
@@ -28,7 +28,8 @@ param(
         'bgt',
         'eye',
         'contagion',
-        'doi'
+        'doi',
+        'pvkii'
         )
 )
 

--- a/support/checkout-deps.sh
+++ b/support/checkout-deps.sh
@@ -61,7 +61,7 @@ if [ -z ${sdks+x} ]; then
 
   if [ $ismac -eq 0 ]; then
     # Add these SDKs for Windows or Linux
-    sdks+=( orangebox blade episode1 bms )
+    sdks+=( orangebox blade episode1 bms pvkii )
 
     # Add more SDKs for Windows only
     if [ $iswin -eq 1 ]; then


### PR DESCRIPTION
Our most recent update saw some changes to tier0 that broke binary compatibility causing MM/SM to fail to load on Linux. This PR splits PVKII into its own engine branch for Metamod, and I have done a corresponding PR for SourceMod as well: https://github.com/alliedmodders/sourcemod/pull/1847

As explained there, this will also require a new hl2sdk branch for 'pvkii' which I have done here: https://github.com/Octoshark/hl2sdk-pvkii/tree/pvkii Again I don't see a way to do a PR that will create a new branch on the original repo. The `pvkii` branch is based off of `sdk2013`

As a side note that I also explained in the other PR, since we've talked about this on Discord, I did go ahead and backport the threadtools changes in that hl2sdk branch from C++20 to C++14. This should avoid any compiler headaches here.

CI will fail until the hl2sdk changes are merged in.