### PR TITLE
Make PVKII also link against stdc++ for Linux

### DIFF
--- a/AMBuildScript
+++ b/AMBuildScript
@@ -392,7 +392,7 @@ class MMSConfig(object):
       if compiler.target.platform in ['linux', 'mac']:
         compiler.defines += ['NO_HOOK_MALLOC', 'NO_MALLOC_OVERRIDE']
 
-    if sdk.name in ['csgo', 'blade'] and compiler.target.platform == 'linux':
+    if sdk.name in ['csgo', 'blade', 'pvkii'] and compiler.target.platform == 'linux':
       compiler.linkflags += ['-lstdc++']
 
 


### PR DESCRIPTION
Fixes undefined symbols as the MM builds use `clang` for both CC and CXX as opposed to `clang++`