### PR TITLE
S2: Add a malloc override

### DIFF
--- a/AMBuildScript
+++ b/AMBuildScript
@@ -395,7 +395,7 @@ class MMSConfig(object):
     if compiler.target.arch == 'x86_64':
       compiler.defines += ['X64BITS', 'PLATFORM_64BITS']
 
-    if sdk.name in ['css', 'hl2dm', 'dods', 'sdk2013', 'bms', 'tf2', 'l4d', 'nucleardawn', 'l4d2', 'dota', 'cs2', 'pvkii']:
+    if sdk.name in ['css', 'hl2dm', 'dods', 'sdk2013', 'bms', 'tf2', 'l4d', 'nucleardawn', 'l4d2', 'pvkii']:
       if compiler.target.platform in ['linux', 'mac']:
         compiler.defines += ['NO_HOOK_MALLOC', 'NO_MALLOC_OVERRIDE']
 

--- a/core/metamod_oslink.cpp
+++ b/core/metamod_oslink.cpp
@@ -94,7 +94,7 @@ bool GetFileOfAddress(void *pAddr, char *buffer, size_t maxlength)
 	return true;
 }
 
-#if defined __GNUC__
+#if defined __GNUC__ && defined(NO_MALLOC_OVERRIDE)
 void * operator new(size_t size) {
 	return malloc(size);
 }


### PR DESCRIPTION
 - Fixes `free(): invalid pointer` crash with `CUtlVector<CUtlString>` into `Source2Provider::Notify_DLLInit_Pre()`
 
Now MetaMod can be run on Source 2 using the Linux platform
 