### PR TITLE
convert UTIL_TrimRight/TrimLeft to use std string internally

### DIFF
--- a/core/metamod_util.cpp
+++ b/core/metamod_util.cpp
@@ -88,27 +88,6 @@ void UTIL_TrimLeft(char *buffer)
     std::string s(buffer);
     ltrim(s);
     strcpy(buffer, s.c_str());
-
-#if 0
-	/* Let's think of this as our iterator */
-	char *i = buffer;
-
-	/* Make sure the buffer isn't null */
-	if (i && *i)
-	{
-		/* Add up number of whitespace characters */
-		while(isspace((unsigned char) *i))
-		{
-			i++;
-		}
-
-		/* If whitespace chars in buffer then adjust string so first non-whitespace char is at start of buffer */
-		if (i != buffer)
-		{
-			memmove(buffer, i, (strlen(i) + 1) * sizeof(char));
-		}
-	}
-#endif 
 }
 
 void UTIL_TrimRight(char *buffer)
@@ -116,25 +95,6 @@ void UTIL_TrimRight(char *buffer)
     std::string s(buffer);
     rtrim(s);
     strcpy(buffer, s.c_str());
-
-#if 0
-	/* Make sure buffer isn't null */
-	if (buffer)
-	{
-		size_t len = strlen(buffer);
-
-		/* Loop through buffer backwards while replacing whitespace chars with null chars */
-		for (size_t i = len - 1; i < len; i--)
-		{
-			if (isspace((unsigned char) buffer[i]))
-			{
-				buffer[i] = '\0';
-			} else {
-				break;
-			}
-		}
-	}
-#endif
 }
 
 bool UTIL_PathCmp(const char *path1, const char *path2)

--- a/core/metamod_util.cpp
+++ b/core/metamod_util.cpp
@@ -30,6 +30,7 @@
 #include <stdio.h>
 #include <string>
 #include <vector>
+#include <algorithm>
 #include "metamod_util.h"
 #include "metamod_oslink.h"
 

--- a/core/metamod_util.cpp
+++ b/core/metamod_util.cpp
@@ -68,8 +68,28 @@ const char *UTIL_GetExtension(const char *file)
 	return NULL;
 }
 
+// https://stackoverflow.com/a/217605
+// trim from start (in place)
+static inline void ltrim(std::string& s) {
+    s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](unsigned char ch) {
+        return !std::isspace(ch);
+        }));
+}
+
+// trim from end (in place)
+static inline void rtrim(std::string& s) {
+    s.erase(std::find_if(s.rbegin(), s.rend(), [](unsigned char ch) {
+        return !std::isspace(ch);
+        }).base(), s.end());
+}
+
 void UTIL_TrimLeft(char *buffer)
 {
+    std::string s(buffer);
+    ltrim(s);
+    strcpy(buffer, s.c_str());
+
+#if 0
 	/* Let's think of this as our iterator */
 	char *i = buffer;
 
@@ -88,10 +108,16 @@ void UTIL_TrimLeft(char *buffer)
 			memmove(buffer, i, (strlen(i) + 1) * sizeof(char));
 		}
 	}
+#endif 
 }
 
 void UTIL_TrimRight(char *buffer)
 {
+    std::string s(buffer);
+    rtrim(s);
+    strcpy(buffer, s.c_str());
+
+#if 0
 	/* Make sure buffer isn't null */
 	if (buffer)
 	{
@@ -108,6 +134,7 @@ void UTIL_TrimRight(char *buffer)
 			}
 		}
 	}
+#endif
 }
 
 bool UTIL_PathCmp(const char *path1, const char *path2)


### PR DESCRIPTION
See #118 

Would convert these to take std::string& but they are surrounded by so much C code that it would be way too much of a pain. That's up next, though it really should be commented first for easier rewriting...

Well, eventually. I am bad at C.

This std string trimming code is from stack overflow, over @ https://stackoverflow.com/a/217605 - it's been referenced so many times and is so short that I don't really think there's any point in trying to rewrite the wheel.

I also don't want to use strcpy, but there's not a better way and it's not unsafe because the string is guaranteed to always be the same size or smaller.

Edit:

Also, this requires `<algorithm>`, so be aware