### PR TITLE
Add a function to add multiple files from one folder

### DIFF
--- a/core/AMBuilder
+++ b/core/AMBuilder
@@ -1,6 +1,23 @@
 # vim: set sts=2 ts=8 sw=2 tw=99 et ft=python: 
 import os
 
+# Function to add multiple files from one folder
+# e.g. in binary.sources adding *addFromFolder to unpack the list.
+def addFromFolder(path, extension=".cpp", recursive=False):
+	fileSelection = []
+	
+	for root, dirs, files in os.walk(path):
+		for file in files:
+			if file.endswith(extension):
+				fileSelection.append( os.path.join(root, file) )
+		
+		if not recursive:
+			break # no recursive
+
+	print(fileSelection)
+	return fileSelection
+
+
 for sdk_name in MMS.sdks:
   for cxx in MMS.all_targets:
     sdk = MMS.sdks[sdk_name]


### PR DESCRIPTION
Now you can do something like this. By default it's not on recursive.
```
      binary.sources += [
	    'provider/source2/provider_source2.cpp',
		os.path.join(sdk.path, 'tier1', 'convar.cpp'),
		os.path.join(sdk.path, 'public', 'tier0', 'memoverride.cpp'),
		*addFromFolder( sdk.path + "/entity2" ),
	  ]
```