### PR TITLE
Fix potential issues with s2_sample_mm & memoverride on linux

### DIFF
--- a/samples/s2_sample_mm/AMBuildScript
+++ b/samples/s2_sample_mm/AMBuildScript
@@ -407,7 +407,7 @@ class MMSPluginConfig(object):
     if compiler.target.arch == 'x86_64':
       compiler.defines += ['X64BITS', 'PLATFORM_64BITS']
 
-    if sdk.name in ['css', 'hl2dm', 'dods', 'sdk2013', 'bms', 'tf2', 'l4d', 'nucleardawn', 'l4d2', 'dota', 'cs2', 'pvkii']:
+    if sdk.name in ['css', 'hl2dm', 'dods', 'sdk2013', 'bms', 'tf2', 'l4d', 'nucleardawn', 'l4d2', 'pvkii']:
       if compiler.target.platform in ['linux', 'mac']:
         compiler.defines += ['NO_HOOK_MALLOC', 'NO_MALLOC_OVERRIDE']
 


### PR DESCRIPTION
This pr removes the ``NO_MALLOC_OVERRIDE`` define for s2 games on linux platform, as the games expects it to be used.