### PR TITLE
Duplicate procfs file pointer instead of reopening

### DIFF
--- a/core/sourcehook/sh_memory.h
+++ b/core/sourcehook/sh_memory.h
@@ -58,9 +58,12 @@ namespace SourceHook
 #if SH_SYS == SH_SYS_LINUX
 		// On linux, first check /proc/self/maps
 		unsigned long laddr = reinterpret_cast<unsigned long>(addr);
-
 		bool bFound = false;
-		FILE *pF = fopen("/proc/self/maps", "r");
+
+		// Open once statically, duplicate before using to stay safe
+		// Way way faster than reopening from scratch
+		static FILE *pMasterFile = fopen("/proc/self/maps", "r");
+		FILE *pF = fdopen(dup(fileno(pMasterFile)), "r");
 		if (pF) {
 			// Linux /proc/self/maps -> parse
 			// Format:


### PR DESCRIPTION
This is another significant speedup to GetPageBits. By only opening the file once statically, and just dup-ing it to a local working file pointer it should stay safe while removing most fopen overhead.
Benchmarks:
```
Elapsed CPU Time (CURRENT) = '4.29449' sec.
Elapsed CPU Time per Iteration (CURRENT, 500000) = '8.588978e-06' sec.
Elapsed CPU Time (DUP) = '0.291668' sec.
Elapsed CPU Time per Iteration (DUP, 500000) = '5.833360e-07' sec.
```