### PR TITLE
Fix integer signedness warning in provider_source2.cpp

### DIFF
--- a/core/provider/source2/provider_source2.cpp
+++ b/core/provider/source2/provider_source2.cpp
@@ -112,7 +112,7 @@ void Source2Provider::Notify_DLLInit_Pre(CreateInterfaceFn engineFactory,
 		"SHADER_SOURCE_ROOT"
 	};
 
-	for(int id = 0; id < (sizeof(pathIds) / sizeof(pathIds[0])); id++)
+	for(size_t id = 0; id < (sizeof(pathIds) / sizeof(pathIds[0])); id++)
 	{
 		CUtlVector<CUtlString> searchPaths;
 		baseFs->GetSearchPathsForPathID(pathIds[id], (GetSearchPathTypes_t)0, searchPaths);


### PR DESCRIPTION
```/work/vendor/metamod-source/core/provider/source2/provider_source2.cpp: In member function ‘virtual void Source2Provider::Notify_DLLInit_Pre(CreateInterfaceFn, CreateInterfaceFn)’:
/work/vendor/metamod-source/core/provider/source2/provider_source2.cpp:115:21: error: comparison of integer expressions of different signedness: ‘int’ and ‘long unsigned int’ [-Werror=sign-compare]
  115 |  for(int id = 0; id < (sizeof(pathIds) / sizeof(pathIds[0])); id++)
      |                  ~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors```