### PR TITLE
Add check for -dedicated or -insecure on S2

### DIFF
--- a/loader/gamedll.cpp
+++ b/loader/gamedll.cpp
@@ -758,6 +758,15 @@ mm_PatchConnect(bool patch)
 void *
 mm_GameDllRequest(const char *name, int *ret)
 {
+	if (strncmp(name, "Source2Server", 13) == 0 && !mm_GetCommandArgument("-dedicated") && !mm_GetCommandArgument("-insecure"))
+	{
+		mm_LogFatal("Metamod:Source requires -dedicated or -insecure on the command line to be able to load");
+		if (ret != nullptr)
+			*ret = 1; // IFACE_FAILED
+
+		return nullptr;
+	}
+
 	if (strncmp(name, "Source2ServerConfig", 19) == 0)
 	{
 		g_is_source2 = true;

--- a/loader/loader.cpp
+++ b/loader/loader.cpp
@@ -211,74 +211,7 @@ typedef const char *(*GetGameInfoStringFn)(const char *pszKeyName, const char *p
 void
 mm_GetGameName(char *buffer, size_t size)
 {
-	buffer[0] = '\0';
-
-#if defined _WIN32
-	static char game[128];
-
-	LPWSTR pCmdLine = GetCommandLineW();
-	int argc;
-	LPWSTR *wargv = CommandLineToArgvW(pCmdLine, &argc);
-	for (int i = 0; i < argc; ++i)
-	{
-		if (wcscmp(wargv[i], L"-game") == 0)
-		{
-			if (++i >= argc)
-				break;
-
-			wcstombs(buffer, wargv[i], size);
-			buffer[size-1] = '\0';
-		}
-	}
-
-	LocalFree(wargv);
-
-#elif defined __APPLE__
-	int argc = *_NSGetArgc();
-	char **argv = *_NSGetArgv();
-	for (int i = 0; i < argc; ++i)
-	{
-		if (strcmp(argv[i], "-game") == 0)
-		{
-			if (++i >= argc)
-				break;
-
-			strncpy(buffer, argv[i], size);
-			buffer[size-1] = '\0';
-		}
-	}
-
-#elif defined __linux__
-	FILE *pFile = fopen("/proc/self/cmdline", "rb");
-	if (pFile)
-	{
-		char *arg = NULL;
-		size_t argsize = 0;
-		bool bNextIsGame = false;
-
-		while (getdelim(&arg, &argsize, 0, pFile) != -1)
-		{
-			if (bNextIsGame)
-			{
-				strncpy(buffer, arg, size);
-				buffer[size-1] = '\0';
-				bNextIsGame = false;
-			}
-
-			if (strcmp(arg, "-game") == 0)
-			{
-				bNextIsGame = true;
-			}
-		}
-
-		free(arg);
-		fclose(pFile);
-	}
-#else
-#error unsupported platform
-#endif
-
-	if (buffer[0] == 0)
+	if (!mm_GetCommandArgument("-game", buffer, size))
 	{
 		char tier0_path[PLATFORM_MAX_PATH];
 #ifdef _WIN32

--- a/loader/utility.h
+++ b/loader/utility.h
@@ -69,5 +69,9 @@ mm_GetFileOfAddress(void *pAddr, char *buffer, size_t maxlength);
 extern void *
 mm_FindPattern(const void *libPtr, const char *pattern, size_t len);
 
+// True if arg is present, false if not. If arg has no value, buffer will be set to an empty string.
+extern bool
+mm_GetCommandArgument(const char *argName, char *buffer = nullptr, size_t maxlength = 0);
+
 #endif /* _INCLUDE_METAMOD_SOURCE_LOADER_UTILITY_H_ */
 


### PR DESCRIPTION
Adds safely check to block loading on Source 2 games if neither `-dedicated` or `-insecure` launch args are present.

This is in an attempt to avoid accidental VAC bans (despite mixed reports of whether or not `-insecure` actually functions correctly on S2).