### PR TITLE
Fix MSVC 2017 build issues

### DIFF
--- a/core/metamod_util.cpp
+++ b/core/metamod_util.cpp
@@ -25,7 +25,7 @@
  * Version: $Id$
  */
 
-#include <ctype.h>
+#include <cctype>
 #include <string.h>
 #include <stdio.h>
 #include <string>


### PR DESCRIPTION
This fixes build errors on MSVC 2017 due to missing ``std::isspace`` methods being introduced in the commit https://github.com/alliedmodders/metamod-source/commit/e857fbe90c3f81e50a30246162732232fbbbc161 