### PR TITLE
Fix IMetamodListener events in s2_sample_mm

### DIFF
--- a/samples/s2_sample_mm/sample_mm.cpp
+++ b/samples/s2_sample_mm/sample_mm.cpp
@@ -70,6 +70,9 @@ bool SamplePlugin::Load(PluginId id, ISmmAPI *ismm, char *error, size_t maxlen, 
 	// Currently doesn't work from within mm side, use GetGameGlobals() in the mean time instead
 	// gpGlobals = ismm->GetCGlobals();
 
+	// Required to get the IMetamodListener events
+	g_SMAPI->AddListener( this, this );
+
 	META_CONPRINTF( "Starting plugin.\n" );
 
 	SH_ADD_HOOK_MEMFUNC(IServerGameDLL, GameFrame, server, this, &SamplePlugin::Hook_GameFrame, true);
@@ -157,7 +160,6 @@ void SamplePlugin::Hook_GameFrame( bool simulating, bool bFirstTick, bool bLastT
 	 */
 }
 
-// Potentially might not work
 void SamplePlugin::OnLevelInit( char const *pMapName,
 									 char const *pMapEntities,
 									 char const *pOldLevel,
@@ -168,7 +170,6 @@ void SamplePlugin::OnLevelInit( char const *pMapName,
 	META_CONPRINTF("OnLevelInit(%s)\n", pMapName);
 }
 
-// Potentially might not work
 void SamplePlugin::OnLevelShutdown()
 {
 	META_CONPRINTF("OnLevelShutdown()\n");


### PR DESCRIPTION
This properly adds support for the IMetamodListener events, which were fixed in https://github.com/alliedmodders/metamod-source/commit/b2b9f3d287dcd7a607bfde5d8831a774c84eb7ff, to the s2 sample_mm example plugin.