### PR TITLE
Add missing "LINUX" macro

### DIFF
--- a/AMBuildScript
+++ b/AMBuildScript
@@ -221,7 +221,7 @@ class MMSConfig(object):
 
     # Platform-specifics
     if cxx.target.platform == 'linux':
-      cxx.defines += ['_LINUX', 'POSIX', '_FILE_OFFSET_BITS=64']
+      cxx.defines += ['LINUX', '_LINUX', 'POSIX', '_FILE_OFFSET_BITS=64']
       if cxx.family == 'gcc':
         cxx.linkflags += ['-static-libgcc']
       elif cxx.family == 'clang':

--- a/samples/s1_sample_mm/AMBuildScript
+++ b/samples/s1_sample_mm/AMBuildScript
@@ -252,6 +252,7 @@ class MMSConfig(object):
     if builder.target.platform == 'linux':
       cxx.defines += [
         'POSIX',
+        'LINUX',
         '_LINUX',
       ]
       cxx.linkflags += ['-shared']

--- a/samples/s2_sample_mm/AMBuildScript
+++ b/samples/s2_sample_mm/AMBuildScript
@@ -329,7 +329,7 @@ class MMSPluginConfig(object):
 
     # Platform-specifics
     if cxx.target.platform == 'linux':
-      cxx.defines += ['_LINUX', 'POSIX', '_FILE_OFFSET_BITS=64']
+      cxx.defines += ['LINUX', '_LINUX', 'POSIX', '_FILE_OFFSET_BITS=64']
       if cxx.family == 'gcc':
         cxx.linkflags += ['-static-libgcc']
       elif cxx.family == 'clang':


### PR DESCRIPTION
I found that the "LINUX" macro is not defined during compilation, although it is used in some places in the sdk.
Also when looking at the linux_sdk/Makefile in the sdk I saw that it was defined there.
Perhaps we should define it here and in other projects.

OS:
Ubuntu 20.04.6 LTS

Compiler:
clang version 10.0.0-4ubuntu1 
Target: x86_64-pc-linux-gnu
Thread model: posix
