### PR TITLE
Remove deprecated syntax for compatibility

### DIFF
--- a/core/sourcehook/sh_vector.h
+++ b/core/sourcehook/sh_vector.h
@@ -282,14 +282,14 @@ public:
 	};
 
 	// constructors / destructors
-	CVector<T>()
+	CVector()
 	{
 		m_Size = 0;
 		m_CurrentUsedSize = 0;
 		m_Data = NULL;
 	}
 
-	CVector<T>(const CVector<T> & other)
+	CVector(const CVector<T> & other)
 	{
 		// copy data
 		m_Data = new T [other.m_CurrentUsedSize];
@@ -299,7 +299,7 @@ public:
 			m_Data[i] = other.m_Data[i];
 	}
 
-	~CVector<T>()
+	~CVector()
 	{
 		clear();
 	}


### PR DESCRIPTION
This pull request removes the redudant template argument in constructors, which has been disallowed since C++20.