### PR TITLE
Shut msvc

### DIFF
--- a/core/sourcehook/generate/sourcehook.hxx
+++ b/core/sourcehook/generate/sourcehook.hxx
@@ -907,7 +907,10 @@ SourceHook::CallClass<T> *SH_GET_CALLCLASS(T *p)
 		/* patch mfp */ \
 		*reinterpret_cast<void**>(&mfp) = *reinterpret_cast<void**>(vfnptr); \
 		if (sizeof(mfp) == 2*sizeof(void*)) /* gcc */ \
-			*(reinterpret_cast<void**>(&mfp) + 1) = 0; \
+		{ \
+			void** pleaseShutUpMsvc = reinterpret_cast<void**>(&mfp); \
+			pleaseShutUpMsvc[1] = 0; \
+		} \
 		return SH_MFHCls(hookname)::CallEC(reinterpret_cast< ::SourceHook::EmptyClass* >(ptr), mfp, vfnptr, SH_GLOB_SHPTR); \
 	} \
 	void __SourceHook_FHM_Reconfigure##hookname(int p_vtblindex, int p_vtbloffs, int p_thisptroffs) \

--- a/core/sourcehook/sourcehook.h
+++ b/core/sourcehook/sourcehook.h
@@ -907,7 +907,10 @@ SourceHook::CallClass<T> *SH_GET_CALLCLASS(T *p)
 		/* patch mfp */ \
 		*reinterpret_cast<void**>(&mfp) = *reinterpret_cast<void**>(vfnptr); \
 		if (sizeof(mfp) == 2*sizeof(void*)) /* gcc */ \
-			*(reinterpret_cast<void**>(&mfp) + 1) = 0; \
+		{ \
+			void** pleaseShutUpMsvc = reinterpret_cast<void**>(&mfp); \
+			pleaseShutUpMsvc[1] = 0; \
+		} \
 		return SH_MFHCls(hookname)::CallEC(reinterpret_cast< ::SourceHook::EmptyClass* >(ptr), mfp, vfnptr, SH_GLOB_SHPTR); \
 	} \
 	void __SourceHook_FHM_Reconfigure##hookname(int p_vtblindex, int p_vtbloffs, int p_thisptroffs) \


### PR DESCRIPTION
If enabling compilation for x64, MSVC will complain a lot about this line
`*(reinterpret_cast<void**>(&mfp) + 1) = 0;`
https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4789

So let's hide to msvc by adding an extra variable that this is a member function pointer, so it stops screaming about it.

Edit: Just in case there's confusion why msvc isn't ignoring this part of the code despite the static if statement right above
`if (sizeof(mfp) == 2*sizeof(void*))` the answer is I've no idea. I did a static assert though, in the event that it evaluated to true. But no it doesn't. Msvc just decides to care about this unreachable part of the code, just because.... And I opt'd for this solution, instead of adding even more macros and ifdef. 