### PR TITLE
Fix source2 plugin issues related to stdc++ linking

### DIFF
--- a/core/metamod_oslink.h
+++ b/core/metamod_oslink.h
@@ -65,7 +65,11 @@
 	#include <sys/types.h>
 	#include <dirent.h>
 	typedef		void*			HINSTANCE;
+#ifdef META_IS_SOURCE2
+	#define		dlmount(x)		dlopen(x,RTLD_NOW | RTLD_DEEPBIND)
+#else
 	#define		dlmount(x)		dlopen(x,RTLD_NOW)
+#endif
 	#define		abspath(x, s)	realpath(s, x)
 	#define	PATH_SEP_STR		"/"
 	#define PATH_SEP_CHAR		'/'


### PR DESCRIPTION
The general issue comes from using std stuff that depends on linking order of initialization, due to libengine2.so and other libraries in the cs2 package (generally the s2) to have the libstdc++ statically included in them and being higher in the symbol lookup hierarchy (due to how the game loads them and their order). This causes issues when you try to lookup symbols in a global scope as it falls down to finding symbols in a game libraries instead, which isn't a problem generally for a lot of std stuff, but there are certain functionalities that depends on a specific initialization process to be done which gets overwritten/reinitialized and causes issues on a completely working code.

As an example, currently running this code on a s2_sample plugin would not build the string correctly (the output would be ``test`` without the 1 at the end):
```
std::ostringstream test;
test << "test" << 1;
Msg("Message: %s", test.str().c_str());
```

To combat this issue, statically linking stdc++ to all the plugins and loading them up with RTLD_DEEPBIND flag seems to be the solution. And testing the sample plugin with these fixes, resolves the above issue.

The according pr was also opened at https://github.com/alliedmodders/hl2sdk-manifests/pull/6 to include static libstdc++ linking for s2 titles (cs2 & dota2) and I'll mark this pr as a draft until the manifests are merged to also update the submodule in here with this pr.

Main credit for finding this issue, debugging it and finding a fix for it goes to poggu_, so thanks for that to him!