### PR TITLE
Document and improve s1_sample_mm build

### DIFF
--- a/samples/s1_sample_mm/AMBuildScript
+++ b/samples/s1_sample_mm/AMBuildScript
@@ -191,9 +191,6 @@ class MMSConfig(object):
 
     cxx = builder.DetectCxx()
 
-    if cxx.like('msvc') and len(self.archs) > 1:
-      raise Exception('Building multiple archs with MSVC is not currently supported')
-
     if cxx.behavior == 'gcc':
       cxx.defines += [
         'stricmp=strcasecmp',
@@ -228,9 +225,6 @@ class MMSConfig(object):
       if cxx.family == 'clang':
         if cxx.version >= 'clang-3.9' or cxx.version >= 'apple-clang-10.0':
           cxx.cxxflags += ['-Wno-expansion-to-defined']
-
-    elif cxx.like('msvc'):
-      raise Exception('MSVC builds should use the Visual Studio projects until somebody implements support') # todo: implement MSVC support
 
     # Optimization
     if builder.options.opt == '1':
@@ -275,17 +269,10 @@ class MMSConfig(object):
   def HL2Compiler(self, context, sdk, arch):
     compiler = context.cxx.clone()
 
-    if sdk.name == 'episode1' or sdk.name == 'darkm':
-      compiler.cxxincludes += [
-        os.path.join(context.currentSourcePath),
-        os.path.join(self.mms_root, 'core-legacy'),
-        os.path.join(self.mms_root, 'core-legacy', 'sourcehook'),
-    ]
-    else:
-      compiler.cxxincludes += [
-        os.path.join(context.currentSourcePath),
-        os.path.join(self.mms_root, 'core'),
-        os.path.join(self.mms_root, 'core', 'sourcehook'),
+    compiler.cxxincludes += [
+      os.path.join(context.currentSourcePath),
+      os.path.join(self.mms_root, 'core'),
+      os.path.join(self.mms_root, 'core', 'sourcehook'),
     ]
 
     defines = ['SE_' + PossibleSDKs[i].define + '=' + PossibleSDKs[i].code for i in PossibleSDKs]
@@ -332,18 +319,11 @@ class MMSConfig(object):
     return compiler
 
   def AddVersioning(self, binary, arch):
-    if builder.target.platform == 'windows':
-      # todo: verify this for MSVC support
-      binary.sources += ['version.rc']
-      binary.compiler.rcdefines += [
-        'BINARY_NAME="{0}"'.format(binary.outputFile),
-        'RC_COMPILE'
-      ]
-    elif builder.target.platform == 'mac' and binary.type == 'library':
+    if builder.target.platform == 'mac' and binary.type == 'library':
       binary.compiler.postlink += [
         '-compatibility_version', '1.0.0',
         '-current_version', self.productVersion
-      ]
+    ]
 
     return binary
 

--- a/samples/s1_sample_mm/AMBuildScript
+++ b/samples/s1_sample_mm/AMBuildScript
@@ -323,7 +323,7 @@ class MMSConfig(object):
       binary.compiler.postlink += [
         '-compatibility_version', '1.0.0',
         '-current_version', self.productVersion
-    ]
+      ]
 
     return binary
 

--- a/samples/s1_sample_mm/README.md
+++ b/samples/s1_sample_mm/README.md
@@ -2,3 +2,19 @@ For more information on compiling and reading the plugin's source code, see:
 
 	http://wiki.alliedmods.net/Category:Metamod:Source_Development
 
+Build instructions
+------------------
+
+Make sure ambuild2 is installed: https://github.com/alliedmodders/ambuild
+
+Configure the build (where `--hl2sdk-root` specifies the path to the desired SDK installed by `support/checkout-deps.sh`):
+```
+mkdir build
+cd build
+python ../configure.py --hl2sdk-root C:/Users/user/Documents/GitHub/hl2sdk-episode1
+```
+
+Build:
+```
+ambuild
+```

--- a/samples/s1_sample_mm/README.md
+++ b/samples/s1_sample_mm/README.md
@@ -7,11 +7,18 @@ Build instructions
 
 Make sure ambuild2 is installed: https://github.com/alliedmodders/ambuild
 
-Configure the build (where `--hl2sdk-root` specifies the path to the desired SDK installed by `support/checkout-deps.sh`):
+Configure the build (`--hl2sdk-root` specifies the path where the all SDKs have been installed by `support/checkout-deps.sh` and `--mms_path` is the path to Metamod: Source).
+
+If you only want to compile using a specific SDK you can hack around the requirement to build for all SDKs by modifying the calls to the SDK constructor in the assignment to `PossibleSDKs` in `AMBuildScript` and setting the `platforms` parameter to \[\] for all SDKs that you don't want to compile for.
+
+### Windows
+
+Use Command Prompt as Gitbash doesn't handle the path arguments correctly.
+
 ```
 mkdir build
 cd build
-python ../configure.py --hl2sdk-root C:/Users/user/Documents/GitHub/hl2sdk-episode1
+python ../configure.py --hl2sdk-root C:\Users\user\Documents\GitHub --mms_path C:\Users\user\Documents\GitHub\metamod-source
 ```
 
 Build:

--- a/samples/s1_sample_mm/engine_wrappers.h
+++ b/samples/s1_sample_mm/engine_wrappers.h
@@ -20,10 +20,6 @@
 extern IVEngineServer *engine;
 extern CGlobalVars *gpGlobals;
 
-#if SOURCE_ENGINE == SE_EPISODEONE && defined METAMOD_PLAPI_VERSION
-#error "Metamod:Source 1.6 API is not supported on the old engine."
-#endif
-
 #define ENGINE_CALL(func) SH_CALL(engine, &IVEngineServer::func)
 
 /**


### PR DESCRIPTION
This documents the build process for the s1_sample_mm sample plugin along with a couple of improvements
- Allow s1_sample_mm to be built on Windows
- Fix s1_sample_mm not compiling with the episode1 branch of the Source engine