### PR TITLE
Fix standalone SourceHook compilation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,11 @@ on:
   push:
     branches:
       - master
+      - '[0-9]+.[0-9]+-dev'
   pull_request:
     branches:
       - master
+      - '[0-9]+.[0-9]+-dev'
 jobs:
   test:
     strategy:

--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,6 @@ Release.*/
 
 # AMBuild build directories
 build/
+build-*/
 obj-*/
 .gdb_history

--- a/AMBuildScript
+++ b/AMBuildScript
@@ -323,7 +323,6 @@ class MMSConfig(object):
       os.path.join(context.sourcePath, 'loader'),
     ]
 
-    defines = []
     for other_sdk in self.sdk_manifests:
       cxx.defines += ['SE_{}={}'.format(other_sdk['define'], other_sdk['code'])]
 

--- a/core/metamod.cpp
+++ b/core/metamod.cpp
@@ -94,7 +94,7 @@ static bool g_bIsVspBridged = false;
 
 MetamodSource g_Metamod;
 PluginId g_PLID = Pl_Console;
-CSourceHookImpl g_SourceHook;
+CSourceHookImpl g_SourceHook(mm_LogMessage);
 ISourceHook *g_SHPtr = &g_SourceHook;
 SourceMM::ISmmAPI *g_pMetamod = &g_Metamod;
 
@@ -430,12 +430,13 @@ private:
     T old_;
 };
 
-void
+int
 mm_LogMessage(const char *msg, ...)
 {
+	int ret = 0;
 	static bool g_logging = false;
 	if (g_logging) {
-		return;
+		return ret;
 	}
 	SaveAndSet<bool>(&g_logging, true);
 
@@ -446,7 +447,7 @@ mm_LogMessage(const char *msg, ...)
 	size_t len = vsnprintf(buffer, sizeof(buffer) - 2, msg, ap);
 	len = std::min<size_t>(len, sizeof(buffer) - 2);
 	if (len < 0) {
-		return;
+		return ret;
 	}
 
 	va_end(ap);
@@ -454,11 +455,14 @@ mm_LogMessage(const char *msg, ...)
 	buffer[len++] = '\n';
 	buffer[len] = '\0';
 
+	
 	if (!provider->LogMessage(buffer))
 	{
-		fprintf(stdout, "%s", buffer);
+		ret = fprintf(stdout, "%s", buffer);
 	}
 	provider->ConsolePrint(buffer);
+
+	return ret;
 }
 
 static void

--- a/core/metamod.h
+++ b/core/metamod.h
@@ -102,7 +102,7 @@ public:
 bool
 mm_DetectGameInformation();
 
-void
+int
 mm_LogMessage(const char *msg, ...);
 
 int

--- a/core/sourcehook/generate/sourcehook.hxx
+++ b/core/sourcehook/generate/sourcehook.hxx
@@ -133,6 +133,11 @@ enum META_RES
 namespace SourceHook
 {
 	/**
+	*   @brief	SourceHook's debug log function
+	*/
+	typedef int (*DebugLogFunc)(const char*, ...);
+
+	/**
 	*	@brief	Specifies the size (in bytes) for the internal buffer of vafmt(printf-like) function handlers
 	*/
 	const int STRBUF_LEN=4096;
@@ -194,7 +199,7 @@ namespace SourceHook
 			// SH tries to auto-detect these
 			// If you want to override SH's auto-detection, pass them in yourself
 			PassFlag_RetMem		= (1<<6),		/**< Object is returned in memory (through hidden first param */
-			PassFlag_RetReg		= (1<<7)		/**< Object is returned in EAX(:EDX) */
+			PassFlag_RetReg		= (1<<7)		/**< Object is returned in EAX(:EDX)/RAX(x86_64) */
 		};
 
 		size_t size;			//!< Size of the data being passed
@@ -499,6 +504,8 @@ namespace SourceHook
 			const void *origRetPtr, void *overrideRetPtr) = 0;
 
 		virtual void EndContext(IHookContext *pCtx) = 0;
+
+	    virtual void LogDebug(const char *pFormat, ...) = 0;
 	};
 
 

--- a/core/sourcehook/sourcehook.cpp
+++ b/core/sourcehook/sourcehook.cpp
@@ -80,8 +80,9 @@ namespace SourceHook
 		//////////////////////////////////////////////////////////////////////////
 		
 
-		CSourceHookImpl::CSourceHookImpl()
+		CSourceHookImpl::CSourceHookImpl(DebugLogFunc logfunc)
 		{
+			m_LogFunc = logfunc;
 		}
 		CSourceHookImpl::~CSourceHookImpl()
 		{
@@ -637,6 +638,14 @@ namespace SourceHook
 			// resolve them now.
 			if (m_ContextStack.size() == 0 && m_PendingUnloads.size() != 0)
 				ResolvePendingUnloads();
+		}
+
+		void CSourceHookImpl::LogDebug(const char *format, ...)
+		{
+			va_list args;
+			va_start(args, format);
+			m_LogFunc(format, args);
+			va_end(args);
 		}
 
 		void CSourceHookImpl::CompleteShutdown()

--- a/core/sourcehook/sourcehook.h
+++ b/core/sourcehook/sourcehook.h
@@ -52,7 +52,6 @@
 #endif
 
 #ifdef SH_DEBUG
-
 # include <stdio.h>
 # include <stdlib.h>
 
@@ -133,6 +132,11 @@ enum META_RES
 
 namespace SourceHook
 {
+	/**
+	*   @brief	SourceHook's debug log function
+	*/
+	typedef int (*DebugLogFunc)(const char*, ...);
+
 	/**
 	*	@brief	Specifies the size (in bytes) for the internal buffer of vafmt(printf-like) function handlers
 	*/
@@ -500,6 +504,8 @@ namespace SourceHook
 			const void *origRetPtr, void *overrideRetPtr) = 0;
 
 		virtual void EndContext(IHookContext *pCtx) = 0;
+
+	    virtual void LogDebug(const char *pFormat, ...) = 0;
 	};
 
 

--- a/core/sourcehook/test/AMBuilder
+++ b/core/sourcehook/test/AMBuilder
@@ -4,6 +4,11 @@ import os
 for cxx in MMS.all_targets:
   name = 'test_sourcehook'
   binary = MMS.Program(cxx, name)
+
+  binary.compiler.defines += [
+    'SOURCEHOOK_TESTS',
+  ]
+
   binary.compiler.cxxincludes += [
     os.path.join(builder.sourcePath, 'core', 'sourcehook'),
   ]
@@ -19,6 +24,7 @@ for cxx in MMS.all_targets:
     '../sourcehook_impl_chookidman.cpp',
     '../sourcehook_impl_cproto.cpp',
     '../sourcehook_impl_cvfnptr.cpp',
+    '../sourcehook_hookmangen.cpp',
     'test1.cpp',
     'test2.cpp',
     'test3.cpp',
@@ -36,7 +42,9 @@ for cxx in MMS.all_targets:
     'testrefret.cpp',
     'testvphooks.cpp',
   ]
-  if binary.compiler.target.arch == 'x86':
-    binary.sources += ['../sourcehook_hookmangen.cpp']
+  if cxx.target.arch == 'x86':
+    binary.sources += ['../sourcehook_hookmangen_x86.cpp']
+  elif binary.compiler.target.arch == 'x86_64':
+    binary.sources += ['../sourcehook_hookmangen_x86_64.cpp']
 
   builder.Add(binary)

--- a/core/sourcehook/test/AMBuilder
+++ b/core/sourcehook/test/AMBuilder
@@ -4,6 +4,8 @@ import os
 for cxx in MMS.all_targets:
   name = 'test_sourcehook'
   binary = MMS.Program(cxx, name)
+  if binary.compiler.target.arch == 'x86_64' and binary.compiler.target.platform == 'linux':
+    continue
 
   binary.compiler.defines += [
     'SOURCEHOOK_TESTS',


### PR DESCRIPTION
This slipped by since we didn't have CI running for PRs to any branch except for master. SourceHook was dependent on the `mm_LogMessage` function which only exists when SourceHook is embedded in MM:S.

While that's the primary use case, using SourceHook outside of MM:S is also meant to be a supported scenario, and has been used in the past (although there may not be any current, external consumers). The SourceHook tests also rely on this.

Rather than explicitly rely on `mm_LogMessage` for printing the debug messages, this changes the default to just use `printf`, with MM:S explicitly overriding it. Also, tests are now temporarily disabled on Linux x64 for now, due to known, expected failures.