### PR TITLE
Fix double plugin unload crash on ``meta retry``

### DIFF
--- a/core/metamod_plugins.cpp
+++ b/core/metamod_plugins.cpp
@@ -320,8 +320,9 @@ bool CPluginManager::Retry(PluginId id, char *error, size_t len)
 			}
 			else
 			{
-				//don't really care about the buffer here
-				_Unload(pl, true, buffer, sizeof(buffer)-1);
+				//We don't need to handle any extra unloading,
+				//as if plugin has failed to load it would be
+				//unloaded by _Load() method itself
 
 				//We just wasted an id... reclaim it
 				m_LastId--;
@@ -400,7 +401,8 @@ struct Unloader : public SourceHook::Impl::UnloadListener
 		if (plugin_->m_UnloadFn != NULL)
 			plugin_->m_UnloadFn();
 
-		dlclose(plugin_->m_Lib);
+		if(plugin_->m_Lib)
+			dlclose(plugin_->m_Lib);
 
 		if (destroy_)
 		{


### PR DESCRIPTION
Prevent double plugin unload on ``meta retry`` if the plugin has failed to load on that retry attempt.

Current retry logic checks for plugin load state after a call to ``_Load``, and unloads the plugin if it failed to load
https://github.com/alliedmodders/metamod-source/blob/ccce734e121a6086cb45773d6d3d754e81a81dbb/core/metamod_plugins.cpp#L303-L329
But ``_Load`` method by itself checks for plugin load state and performs unload if it was unsuccessful https://github.com/alliedmodders/metamod-source/blob/ccce734e121a6086cb45773d6d3d754e81a81dbb/core/metamod_plugins.cpp#L599-L604
This causes a double unload if a plugin has failed to load on that retry attempt, thus causing ReadyToUnload to be called twice, where on a second go, plugin_->m_Lib would be nullptr and results in a crash on linux
https://github.com/alliedmodders/metamod-source/blob/ccce734e121a6086cb45773d6d3d754e81a81dbb/core/metamod_plugins.cpp#L398-L416

This pr both, removes the double unload on retry and adds a safeguard on dlclose in ReadyToUnload method to check for potential nullptr.