### PR TITLE
fix: ispaused invalid iterator

### DIFF
--- a/core/sourcehook/sourcehook_impl.h
+++ b/core/sourcehook/sourcehook_impl.h
@@ -256,9 +256,20 @@ namespace SourceHook
 
 			ICleanupTask *m_CleanupTask;
 
+			bool isValidIterator(List<CHook>::iterator &myIter, List<CHook> &myList) {
+				for (auto iter = myList.begin(); iter != myList.end(); ++iter) {
+					if (iter == myIter) {
+						return true;
+					}
+				}
+				return false;
+			}
+
 			void SkipPaused(List<CHook>::iterator &iter, List<CHook> &list)
 			{
-				while (iter != list.end() && iter->IsPaused())
+				if (!iter || !isValidIterator(iter, list))
+					iter = list.end();
+				while (iter != list.end() && iter && iter->IsPaused())
 					++iter;
 			}
 		public:


### PR DESCRIPTION
This fixes that sort of crash:
- https://crash.limetech.org/5aeubpubbsgt

Which happens on this function call:
- https://github.com/alliedmodders/metamod-source/blob/2009298c32735b6de1712ff88e2309c151e5eb31/core/sourcehook/sourcehook_impl_chook.h#L95

Coming from here:
- https://github.com/alliedmodders/metamod-source/blob/4bc5a3a0b7c9b92fc2365ab86f9d7d425459a547/core/sourcehook/sourcehook_impl.h#L259

So from my understanding, this->m_Paused crashes because `this` is null

That's why i am trying to avoid any call with iter being an invalid iterator

i added this on our prod servers since 04/02/2025 and we have not encountered this crash again:
- https://github.com/srcdslab/metamod-source/pull/1#issue-2831162461
- https://stats.nide.gg/hlstats.php?game=css_ze
