### PR TITLE
loader: Detect HL1MP and SDK2013(2025) mods as HL2:DM for now

### DIFF
--- a/loader/loader.cpp
+++ b/loader/loader.cpp
@@ -386,6 +386,12 @@ mm_DetermineBackendS1(QueryValveInterface engineFactory, QueryValveInterface ser
 					{
 						return MMBackend_Mock;
 					}
+					else if (serverFactory("ServerGameClients005", NULL) != nullptr)
+					{
+						// 2025 version of SDK 2013, or maybe hl1mp, or anything else shaped like those.
+						// We may later make a separate SDK for this branch. For now, they match, we'll hack it
+						return MMBackend_HL2DM;
+					}
 					else
 					{
 						return MMBackend_SDK2013;


### PR DESCRIPTION
Not tested yet. Also, not 100% sold on this approach, but it should work well enough for now and avoids 1-2 new sdks and 2-4 more builds