### PR TITLE
Fix missing includes and standardize non-system includes to quotes

### DIFF
--- a/core/IPluginManager.h
+++ b/core/IPluginManager.h
@@ -33,7 +33,7 @@
  * @file IPluginManager.h
  */
 
-#include <ISmmPluginExt.h>
+#include "ISmmPluginExt.h"
 
 namespace SourceMM
 {

--- a/core/ISmmAPI.h
+++ b/core/ISmmAPI.h
@@ -33,9 +33,10 @@
  * @file ISmmAPI.h
  */
 
-#include <stdarg.h>
-#include <sourcehook.h>
-#include <IPluginManager.h>
+#include <cstdarg>
+
+#include "sourcehook.h"
+#include "IPluginManager.h"
 
 #if defined META_NO_HL2SDK
 class CGlobalVars;
@@ -44,7 +45,7 @@ class ConCommandBase;
 typedef ConCommandBase ProviderConVar;
 typedef ConCommandBase ProviderConCommand;
 #else
-#include <eiface.h>
+#include "eiface.h"
 
 #if defined META_IS_SOURCE2
 typedef ConVarRefAbstract ProviderConVar;
@@ -55,9 +56,6 @@ typedef ConCommandBase ProviderConVar;
 typedef ConCommandBase ProviderConCommand;
 #endif
 #endif
-
-#include <ISmmPlugin.h>
-#include <ISmmPluginExt.h>
 
 #define	MMIFACE_SOURCEHOOK		"ISourceHook"			/**< ISourceHook Pointer */
 #define	MMIFACE_PLMANAGER		"IPluginManager"		/**< SourceMM Plugin Functions */

--- a/core/ISmmPlugin.h
+++ b/core/ISmmPlugin.h
@@ -34,16 +34,16 @@
  * The pure-virtual ISmmPlugin callbacks must be implemented for the load to load.
  */
 
-#include <sourcehook.h>
-#include <IPluginManager.h>
-#include <ISmmAPI.h>
-#include <ISmmPluginExt.h>
+#include "sourcehook.h"
+#include "IPluginManager.h"
+#include "ISmmAPI.h"
+#include "ISmmPluginExt.h"
 
 #ifndef META_NO_HL2SDK
 #if META_IS_SOURCE2
-#include <interfaces/interfaces.h>
+#include "interfaces/interfaces.h"
 #else
-#include <tier1/interface.h>
+#include "tier1/interface.h"
 #endif
 #endif
 

--- a/core/ISmmPluginExt.h
+++ b/core/ISmmPluginExt.h
@@ -26,7 +26,7 @@
 #ifndef _INCLUDE_METAMOD_SOURCE_PLUGIN_EXT_H_
 #define _INCLUDE_METAMOD_SOURCE_PLUGIN_EXT_H_
 
-#include <stddef.h>
+#include <cstddef>
 
 /**
  * @file ISmmPluginExt.h Provides an alternate method for loading plugins, 

--- a/core/gamedll_bridge.cpp
+++ b/core/gamedll_bridge.cpp
@@ -23,11 +23,12 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include <assert.h>
+#include <cassert>
+
 #include "metamod.h"
 #include "metamod_plugins.h"
 #include "metamod_util.h"
-#include <loader_bridge.h>
+#include "loader_bridge.h"
 #include "provider/provider_base.h"
 
 using namespace SourceMM;

--- a/core/metamod.cpp
+++ b/core/metamod.cpp
@@ -23,18 +23,19 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include <stdio.h>
+#include <cstdio>
+#include <sys/stat.h>
+
 #include "metamod_oslink.h"
 #include "metamod.h"
-#include <interface.h>
-#include <eiface.h>
-#include <metamod_version.h>
+#include "interface.h"
+#include "eiface.h"
+#include "metamod_version.h"
 #include "metamod_provider.h"
 #include "metamod_plugins.h"
 #include "metamod_util.h"
 #include "metamod_console.h"
 #include "provider/provider_base.h"
-#include <sys/stat.h>
 
 #define X64_SUFFIX ".x64"
 

--- a/core/metamod.h
+++ b/core/metamod.h
@@ -31,12 +31,12 @@
  * @file sourcemm.h
  */
 
-#include <interface.h>
-#include <eiface.h>
-#include <sourcehook/sourcehook_impl.h>
-#include <sourcehook/sourcehook_hookmangen.h>
-#include <sourcehook/sourcehook.h>
-#include <ISmmPlugin.h>
+#include "interface.h"
+#include "eiface.h"
+#include "sourcehook/sourcehook_impl.h"
+#include "sourcehook/sourcehook_hookmangen.h"
+#include "sourcehook/sourcehook.h"
+#include "ISmmPlugin.h"
 #include "metamod_provider.h"
 
 using namespace SourceMM;

--- a/core/metamod_console.cpp
+++ b/core/metamod_console.cpp
@@ -23,10 +23,11 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include <stdio.h>
+#include <cstdio>
+#include <cctype>
+
 #include "metamod_oslink.h"
-#include <ctype.h>
-#include <metamod_version.h>
+#include "metamod_version.h"
 #include "metamod.h"
 #include "metamod_util.h"
 #include "metamod_console.h"

--- a/core/metamod_convar.h
+++ b/core/metamod_convar.h
@@ -32,7 +32,7 @@
 #define private public
 #endif
 
-#include <convar.h>
+#include "convar.h"
 
 #ifndef META_IS_SOURCE2
 #undef protected

--- a/core/metamod_oslink.cpp
+++ b/core/metamod_oslink.cpp
@@ -25,13 +25,13 @@
  * Version: $Id$
  */
 
-#include <stdio.h>
-#include "metamod_oslink.h"
-#include <stdlib.h>
-#include <stdio.h>
+#include <cstdlib>
+#include <cstdio>
 #if defined __linux__ || defined __APPLE__
-#include <errno.h>
+#include <cerrno>
 #endif
+
+#include "metamod_oslink.h"
 
 #if defined __WIN32__ || defined _WIN32 || defined WIN32
 const char *dlerror()

--- a/core/metamod_oslink.h
+++ b/core/metamod_oslink.h
@@ -85,7 +85,7 @@
 #endif
 
 #if defined __linux__ || defined __APPLE__
-	#include <errno.h>
+	#include <cerrno>
 	int GetLastError();
 #endif
 
@@ -103,7 +103,7 @@ bool GetFileOfAddress(void *pAddr, char *buffer, size_t maxlength);
 	typedef __int32				int32_t;
 	typedef unsigned __int32	uint32_t;
 #elif defined __GNUC__
-#include <stdint.h>
+#include <cstdint>
 #endif
 
 #if !defined __linux__ && !defined __APPLE__

--- a/core/metamod_plugins.cpp
+++ b/core/metamod_plugins.cpp
@@ -23,11 +23,10 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include <stdio.h>
-
+#include <cstdio>
 #include <memory>
 
-#include <amtl/am-string.h>
+#include "amtl/am-string.h"
 #include "metamod_oslink.h"
 #include "metamod.h"
 #include "metamod_plugins.h"

--- a/core/metamod_plugins.h
+++ b/core/metamod_plugins.h
@@ -33,12 +33,13 @@
  * @file CPlugin.cpp
  */
 
-#include <interface.h>
-#include <eiface.h>
-#include <sh_list.h>
-#include <sh_string.h>
-#include <IPluginManager.h>
-#include <ISmmPluginExt.h>
+#include "interface.h"
+#include "eiface.h"
+#include "sh_list.h"
+#include "sh_string.h"
+#include "ISmmAPI.h"
+#include "IPluginManager.h"
+#include "ISmmPluginExt.h"
 #include "metamod_oslink.h"
 
 /**

--- a/core/metamod_provider.h
+++ b/core/metamod_provider.h
@@ -26,6 +26,8 @@
 #ifndef _INCLUDE_METAMOD_SOURCE_SUPPORT_H_
 #define _INCLUDE_METAMOD_SOURCE_SUPPORT_H_
 
+#include "ISmmAPI.h"
+
 namespace SourceMM
 {
 	class MetamodSourceConVar;

--- a/core/metamod_util.cpp
+++ b/core/metamod_util.cpp
@@ -26,11 +26,12 @@
  */
 
 #include <cctype>
-#include <string.h>
-#include <stdio.h>
+#include <cstring>
+#include <cstdio>
 #include <string>
 #include <vector>
 #include <algorithm>
+
 #include "metamod_util.h"
 #include "metamod_oslink.h"
 

--- a/core/metamod_util.h
+++ b/core/metamod_util.h
@@ -28,7 +28,8 @@
 #ifndef _INCLUDE_UTIL_H
 #define _INCLUDE_UTIL_H
 
-#include <stdarg.h>
+#include <cstddef>
+#include <cstdarg>
 
 #if defined(WIN32) || defined(_WIN32)
 #define BINARY_EXT ".dll"

--- a/core/provider/provider_base.cpp
+++ b/core/provider/provider_base.cpp
@@ -23,18 +23,19 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include <stdio.h>
-#include <setjmp.h>
+#include <cstdio>
+#include <csetjmp>
+
 #include "../metamod_oslink.h"
-#include <sourcehook.h>
-#include <eiface.h>
-#include <tier0/icommandline.h>
 #include "../metamod_util.h"
+#include "sourcehook.h"
+#include "eiface.h"
+#include "tier0/icommandline.h"
 #include "provider_base.h"
 #include "metamod_console.h"
-#include <filesystem.h>
+#include "filesystem.h"
 #include "metamod.h"
-#include <tier1/KeyValues.h>
+#include "tier1/KeyValues.h"
 
 
 /* Imports */

--- a/core/provider/provider_base.h
+++ b/core/provider/provider_base.h
@@ -32,10 +32,10 @@
 #define DEBUG2
 #undef _DEBUG
 #endif
-#include <sourcehook.h>
-#include <sh_memfuncinfo.h>
+#include "sourcehook.h"
+#include "sh_memfuncinfo.h"
 #if !defined META_IS_SOURCE2
-#include <iserverplugin.h>
+#include "iserverplugin.h"
 #endif
 #include "ISmmAPI.h"
 #include "metamod_provider.h"

--- a/core/provider/source/provider_source.cpp
+++ b/core/provider/source/provider_source.cpp
@@ -23,15 +23,15 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include "provider_source.h"
-#include <metamod.h>
-#include <metamod_util.h>
-#include <metamod_console.h>
-#include <KeyValues.h>
-#include <filesystem.h>
-#include <tier0/icommandline.h>
+ #include <csetjmp>
 
-#include <setjmp.h>
+#include "provider_source.h"
+#include "metamod.h"
+#include "metamod_util.h"
+#include "metamod_console.h"
+#include "KeyValues.h"
+#include "filesystem.h"
+#include "tier0/icommandline.h"
 
 #if SOURCE_ENGINE >= SE_ORANGEBOX
 void LocalCommand_Meta(const CCommand& args);

--- a/core/provider/source/provider_source.h
+++ b/core/provider/source/provider_source.h
@@ -28,10 +28,11 @@
 #ifndef _INCLUDE_METAMOD_SOURCE_SOURCE1_PROVIDER_H_
 #define _INCLUDE_METAMOD_SOURCE_SOURCE1_PROVIDER_H_
 
-#include "../provider_base.h"
 #include <string>
 #include <vector>
-#include <sh_list.h>
+
+#include "../provider_base.h"
+#include "sh_list.h"
 
 class IFileSystem;
 

--- a/core/provider/source2/provider_source2.cpp
+++ b/core/provider/source2/provider_source2.cpp
@@ -24,14 +24,14 @@
  */
 
 #include "provider_source2.h"
-#include <metamod.h>
-#include <metamod_util.h>
-#include <metamod_console.h>
-#include <amtl/am-string.h>
-#include <eiface.h>
-#include <KeyValues.h>
-#include <filesystem.h>
-#include <iserver.h>
+#include "metamod.h"
+#include "metamod_util.h"
+#include "metamod_console.h"
+#include "amtl/am-string.h"
+#include "eiface.h"
+#include "KeyValues.h"
+#include "filesystem.h"
+#include "iserver.h"
 
 
 static Source2Provider g_Source2Provider;

--- a/core/provider/source2/provider_source2.h
+++ b/core/provider/source2/provider_source2.h
@@ -28,11 +28,12 @@
 #ifndef _INCLUDE_METAMOD_SOURCE_SOURCE2_PROVIDER_H_
 #define _INCLUDE_METAMOD_SOURCE_SOURCE2_PROVIDER_H_
 
-#include "../provider_base.h"
-#include <tier1/utlvector.h>
-#include <IEngineService.h>
 #include <string>
 #include <vector>
+
+#include "../provider_base.h"
+#include "tier1/utlvector.h"
+#include "IEngineService.h"
 
 // TODO: is this still needed for Dota or CS2 on any platform?
 #if SOURCE_ENGINE == SE_DOTA && defined( _WIN32 )

--- a/core/sourcehook/sh_list.h
+++ b/core/sourcehook/sh_list.h
@@ -11,7 +11,6 @@
 #ifndef _INCLUDE_SMM_LIST_H
 #define _INCLUDE_SMM_LIST_H
 
-#include <new>
 #include <stdlib.h>
 
 namespace SourceHook

--- a/core/sourcehook/sh_memory.h
+++ b/core/sourcehook/sh_memory.h
@@ -12,6 +12,8 @@
 #ifndef __SHINT_MEMORY_H__
 #define __SHINT_MEMORY_H__
 
+#include "sourcehook.h"
+
 // Feb 17 / 2005:
 //  Unprotect now sets to readwrite
 //  The vtable doesn't need to be executable anyway

--- a/core/sourcehook/sh_vector.h
+++ b/core/sourcehook/sh_vector.h
@@ -11,6 +11,7 @@
 #ifndef __CVECTOR_H__
 #define __CVECTOR_H__
 
+#include <cstddef>
 #include <assert.h>
 
 //This file originally from AMX Mod X

--- a/core/sourcehook/sourcehook_hookmangen.cpp
+++ b/core/sourcehook/sourcehook_hookmangen.cpp
@@ -15,7 +15,9 @@
 // http://www.angelcode.com/dev/callconv/callconv.html
 // http://www.arl.wustl.edu/~lockwood/class/cs306/books/artofasm/Chapter_6/CH06-1.html
 
-#include <stdio.h>
+#include <cstdio>
+#include <cstdarg>							// we might need the address of vsnprintf
+
 #include "sourcehook_impl.h"
 #include "sourcehook_hookmangen.h"
 #if defined( PLATFORM_64BITS ) && !defined( _LINUX )
@@ -26,7 +28,6 @@ typedef SourceHook::Impl::x64GenContext SHGenContext;
 typedef SourceHook::Impl::GenContext SHGenContext;
 #endif
 #include "sh_memory.h"
-#include <stdarg.h>							// we might need the address of vsnprintf
 
 #if SH_COMP == SH_COMP_MSVC
 # define GCC_ONLY(x)

--- a/core/sourcehook/sourcehook_hookmangen.h
+++ b/core/sourcehook/sourcehook_hookmangen.h
@@ -11,10 +11,12 @@
 #ifndef __SOURCEHOOK_HOOKMANGEN_H__
 #define __SOURCEHOOK_HOOKMANGEN_H__
 
-#include "sh_pagealloc.h"
-#include "sh_asm.h"
 #include <list>
 #include <memory>
+
+#include "sourcehook_impl_cproto.h"
+#include "sh_pagealloc.h"
+#include "sh_asm.h"
 
 namespace SourceHook
 {
@@ -23,7 +25,7 @@ namespace SourceHook
 
 		// Code gen stuff
 #if SH_COMP == SH_COMP_GCC
-#include <stdint.h>
+#include <cstdint>
 		typedef int8_t jit_int8_t;
 		typedef uint8_t jit_uint8_t;
 		typedef int32_t jit_int32_t;

--- a/core/sourcehook/sourcehook_hookmangen_x86.cpp
+++ b/core/sourcehook/sourcehook_hookmangen_x86.cpp
@@ -15,12 +15,13 @@
 // http://www.angelcode.com/dev/callconv/callconv.html
 // http://www.arl.wustl.edu/~lockwood/class/cs306/books/artofasm/Chapter_6/CH06-1.html
 
-#include <stdio.h>
+#include <cstdio>
+#include <cstdarg>							// we might need the address of vsnprintf
+
 #include "sourcehook_impl.h"
 #include "sourcehook_hookmangen.h"
 #include "sourcehook_hookmangen_x86.h"
 #include "sh_memory.h"
-#include <stdarg.h>							// we might need the address of vsnprintf
 
 #if SH_COMP == SH_COMP_MSVC
 # define GCC_ONLY(x)

--- a/core/sourcehook/sourcehook_hookmangen_x86.h
+++ b/core/sourcehook/sourcehook_hookmangen_x86.h
@@ -12,8 +12,9 @@
 #ifndef __SOURCEHOOK_HOOKMANGEN_X86_H__
 #define __SOURCEHOOK_HOOKMANGEN_X86_H__
 
-#include <limits.h>
+#include <climits>
 
+#include "sourcehook_hookmangen.h"
 #include "sh_asm.h"
 
 #undef REG_EAX

--- a/core/sourcehook/sourcehook_hookmangen_x86_64.cpp
+++ b/core/sourcehook/sourcehook_hookmangen_x86_64.cpp
@@ -15,8 +15,9 @@
 // https://learn.microsoft.com/en-us/cpp/build/x64-calling-convention
 // https://refspecs.linuxbase.orgz/elf/x86_64-abi-0.99.pdf
 
-#include <stdio.h>
+#include <cstdio>
 #include <string>
+
 #include "sourcehook_impl.h"
 #include "sourcehook_hookmangen.h"
 #include "sourcehook_hookmangen_x86_64.h"
@@ -24,10 +25,10 @@
 
 #include "metamod_oslink.h"
 #include "metamod.h"
-#include <interface.h>
-#include <eiface.h>
-#include <metamod_version.h>
-#include <metamod_provider.h>
+#include "interface.h"
+#include "eiface.h"
+#include "metamod_version.h"
+#include "metamod_provider.h"
 
 extern SourceHook::ISourceHook *g_SHPtr;
 extern SourceMM::IMetamodSourceProvider *provider;

--- a/core/sourcehook/sourcehook_hookmangen_x86_64.h
+++ b/core/sourcehook/sourcehook_hookmangen_x86_64.h
@@ -12,7 +12,8 @@
 #define __SOURCEHOOK_HOOKMANGEN_X86_64_H__
 
 #include <cstdint>
-#include <limits.h>
+#include <climits>
+
 #include "sh_asm_x86_64.h"
 
 namespace SourceHook

--- a/core/sourcehook/sourcehook_impl_chook.h
+++ b/core/sourcehook/sourcehook_impl_chook.h
@@ -11,6 +11,8 @@
 #ifndef __SOURCEHOOK_IMPL_CHOOK_H__
 #define __SOURCEHOOK_IMPL_CHOOK_H__
 
+#include "sourcehook.h"
+
 namespace SourceHook
 {
 	namespace Impl

--- a/core/sourcehook/sourcehook_impl_chookidman.h
+++ b/core/sourcehook/sourcehook_impl_chookidman.h
@@ -11,6 +11,8 @@
 #ifndef __SOURCEHOOK_IMPL_CHOOKIDMAN_H__
 #define __SOURCEHOOK_IMPL_CHOOKIDMAN_H__
 
+#include "sourcehook.h"
+#include "sourcehook_impl_cproto.h"
 #include "sh_vector.h"
 
 namespace SourceHook

--- a/core/sourcehook/sourcehook_impl_ciface.h
+++ b/core/sourcehook/sourcehook_impl_ciface.h
@@ -12,6 +12,7 @@
 #define __SOURCEHOOK_IMPL_CIFACE_H__
 
 #include "sh_list.h"
+#include "sourcehook_impl_chook.h"
 
 namespace SourceHook
 {

--- a/core/sourcehook/sourcehook_impl_cproto.h
+++ b/core/sourcehook/sourcehook_impl_cproto.h
@@ -11,6 +11,11 @@
 #ifndef __SOURCEHOOK_IMPL_CPROTO_H__
 #define __SOURCEHOOK_IMPL_CPROTO_H__
 
+#include <cstddef>
+
+#include "sourcehook.h"
+#include "sh_vector.h"
+
 namespace SourceHook
 {
 	namespace Impl

--- a/core/sourcehook/sourcehook_impl_cvfnptr.h
+++ b/core/sourcehook/sourcehook_impl_cvfnptr.h
@@ -15,6 +15,8 @@
 #include "sh_memory.h"
 #include "sh_pagealloc.h"
 #include "sourcehook_impl_cleanuptask.h"
+#include "sourcehook_impl_chookmaninfo.h"
+#include "sourcehook_impl_ciface.h"
 
 namespace SourceHook
 {

--- a/core/vsp_bridge.cpp
+++ b/core/vsp_bridge.cpp
@@ -22,16 +22,16 @@
  * misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  */
+#include <cassert>
 
 #include "metamod.h"
 #include "metamod_util.h"
-#include <interface.h>
-#include <eiface.h>
-#include <iplayerinfo.h>
-#include <assert.h>
-#include <loader_bridge.h>
-#include <metamod_version.h>
-#include <sh_string.h>
+#include "interface.h"
+#include "eiface.h"
+#include "iplayerinfo.h"
+#include "loader_bridge.h"
+#include "metamod_version.h"
+#include "sh_string.h"
 #include "provider/provider_base.h"
 
 #if SOURCE_ENGINE >= SE_ORANGEBOX

--- a/loader/gamedll.cpp
+++ b/loader/gamedll.cpp
@@ -23,15 +23,16 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include <stdio.h>
-#include <ctype.h>
-#include <string.h>
-#include <assert.h>
-#include <stdlib.h>
-#include <stddef.h>
+#include <cstdio>
+#include <cctype>
+#include <cstring>
+#include <cassert>
+#include <cstdlib>
+#include <cstddef>
+
 #include "loader.h"
-#include <sh_memfuncinfo.h>
-#include <sh_memory.h>
+#include "sh_memfuncinfo.h"
+#include "sh_memory.h"
 #include "utility.h"
 #include "gamedll.h"
 

--- a/loader/loader.cpp
+++ b/loader/loader.cpp
@@ -23,14 +23,15 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include <time.h>
-#include <assert.h>
-#include <stdarg.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include <ctime>
+#include <cassert>
+#include <cstdarg>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <cstdint>
 #include <cstdlib>
+
 #include "loader.h"
 #include "serverplugin.h"
 #include "gamedll.h"

--- a/loader/loader_bridge.h
+++ b/loader/loader_bridge.h
@@ -26,6 +26,8 @@
 #ifndef _INCLUDE_METAMOD_SOURCE_LOADER_BRIDGE_H_
 #define _INCLUDE_METAMOD_SOURCE_LOADER_BRIDGE_H_
 
+#include <cstddef>
+
 typedef void* (*QueryValveInterface)(const char *pName, int *pReturnCode);
 class IServerPluginCallbacks;
 

--- a/loader/serverplugin.cpp
+++ b/loader/serverplugin.cpp
@@ -23,13 +23,14 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include <stdio.h>
-#include <string.h>
-#include <assert.h>
-#include <stddef.h>
+#include <cstdio>
+#include <cstring>
+#include <cassert>
+#include <cstddef>
+
 #include "loader.h"
-#include <sh_memfuncinfo.h>
-#include <sh_memory.h>
+#include "sh_memfuncinfo.h"
+#include "sh_memory.h"
 #include "serverplugin.h"
 #include "gamedll.h"
 

--- a/loader/utility.cpp
+++ b/loader/utility.cpp
@@ -25,12 +25,13 @@
  * Version: $Id$
  */
 
-#include <stdio.h>
-#include <assert.h>
-#include <string.h>
-#include <ctype.h>
-#include <stdarg.h>
-#include <stdlib.h>
+#include <cstdio>
+#include <cassert>
+#include <cstring>
+#include <cctype>
+#include <cstdarg>
+#include <cstdlib>
+
 #include "loader.h"
 #include "utility.h"
 

--- a/loader/utility.h
+++ b/loader/utility.h
@@ -28,7 +28,7 @@
 #ifndef _INCLUDE_METAMOD_SOURCE_LOADER_UTILITY_H_
 #define _INCLUDE_METAMOD_SOURCE_LOADER_UTILITY_H_
 
-#include <stddef.h>
+#include <cstddef>
 
 extern size_t
 mm_Format(char *buffer, size_t maxlength, const char *fmt, ...);

--- a/public/metamod_version.h
+++ b/public/metamod_version.h
@@ -37,9 +37,9 @@
 #  undef MMS_USE_VERSIONLIB
 # endif
 # if defined MMS_USE_VERSIONLIB
-#  include <versionlib.h>
+#  include "versionlib.h"
 # else 
-#  include <metamod_version_auto.h>
+#  include "metamod_version_auto.h"
 # endif
 #else
 #define MMS_BUILD_TAG		"manual"

--- a/versionlib/versionlib.cpp
+++ b/versionlib/versionlib.cpp
@@ -23,8 +23,8 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
-#include <metamod_version.h>
-#include <versionlib.h>
+#include "metamod_version.h"
+#include "versionlib.h"
 
 const char *METAMOD_LOCAL_REV = MMS_BUILD_LOCAL_REV;
 const char *METAMOD_SHA = MMS_BUILD_CSET;


### PR DESCRIPTION
 - Clangd pointed out missing includes in several files that I added.
 - Cleaned up the mixed usage of angle brackets and quotes to use angles exclusively for the system includes, and quotes for all the mm/sdk includes.
 - Standardized the system includes that support it to the c++ style `<c*>`.