### PR TITLE
Prevent ARRAYSIZE undef

### DIFF
--- a/AMBuildScript
+++ b/AMBuildScript
@@ -139,6 +139,7 @@ class MMSConfig(object):
         '-fno-rtti',
         '-fno-threadsafe-statics',
         '-Wno-non-virtual-dtor',
+        '-Wno-class-memaccess',
         '-Wno-overloaded-virtual',
         '-Wno-register',
       ]

--- a/core/metamod_oslink.h
+++ b/core/metamod_oslink.h
@@ -34,9 +34,7 @@
 #if defined __WIN32__ || defined _WIN32 || defined WIN32
 	#define WIN32_LEAN_AND_MEAN
 	#define OS_WIN32
-	#if defined _MSC_VER && _MSC_VER >= 1400
-		#undef ARRAYSIZE
-	#else
+	#if !defined _MSC_VER || _MSC_VER < 1400
 		#define mkdir(a) _mkdir(a)
 	#endif
 	#include <windows.h>


### PR DESCRIPTION
Currently this undef prevents compilation of the mm plugins with latest sdk2013 variants and source2 hl2sdk's (cs2, dota, deadlock) if certain include order is met. The cause is metamod_oslink.h which undefs the definition from hl2sdk coming from commonmacros.h which later results in compilation errors if ARRAYSIZE is used anywhere down the line.
https://github.com/alliedmodders/hl2sdk/blob/4c27c1305c5e042ae1f62f6dc6ba7e96fd06e05d/public/tier0/commonmacros.h#L152-L155

If there's someone with more in-depth knowledge on the history of this undef or if it's still needed, I'd gladly discuss other solutions to this issue, but currently all the hl2sdks do build fine with that removed on the modern msvc, where I assume problems might arise if older build tooling is used? I do see that the sdk definitions of ARRAYSIZE are just a copy from win api winnt.h header, but that doesn't get used anyhow in the build process so shouldn't result in a conflict anyhow other than if older msvc forcefully dragged that include in?

Additionally this pr fixes gcc compilation of the latest sdk2013 hl2sdk variants by adding ``-Wno-class-memaccess`` compilation flag as otherwise it fails to compile with that error (tested on gcc 9.4).