### PR TITLE
Scan all PT_LOAD segments on Linux for mm_FindPattern

### DIFF
--- a/loader/utility.cpp
+++ b/loader/utility.cpp
@@ -506,18 +506,14 @@ mm_GetLibraryInfo(const void *libPtr, DynLibInfo &lib)
 	{
 		ElfPHeader &hdr = phdr[i];
 
-		/* We only really care about the segment with executable code */
-		if (hdr.p_type == PT_LOAD && hdr.p_flags == (PF_X|PF_R))
+		if ( hdr.p_type == PT_LOAD )
 		{
-			/* From glibc, elf/dl-load.c:
-			 * c->mapend = ((ph->p_vaddr + ph->p_filesz + GLRO(dl_pagesize) - 1)
-			 * & ~(GLRO(dl_pagesize) - 1));
-			 *
-			 * In glibc, the segment file size is aligned up to the nearest page size and
-			 * added to the virtual address of the segment. We just want the size here.
-			 */
-			lib.memorySize = PAGE_ALIGN_UP(hdr.p_filesz);
-			break;
+			// track the highest address to determine total memory span 
+			size_t segmentEnd = hdr.p_vaddr + hdr.p_memsz;
+			if ( segmentEnd > lib.memorySize )
+			{
+				lib.memorySize = segmentEnd;
+			}
 		}
 	}
 


### PR DESCRIPTION
Unlike in x86 where .rodata might be in the same segment as .text (or at least close enough that PAGE_ALIGN_UP covered it by luck here lol), x64 strictly separates .rodata into its own PF_R only segment. As mm_GetLibraryInfo would only scan the first segment with executable permissions on linux, it would cause mm_FindPattern to miss .rodata in x64

This PR matches the behavior of the Windows and macOS implementations of mm_FindPattern by going over all of the module's PT_LOAD segments instead