### PR TITLE
Fix Load Failure on The Ship

### DIFF
--- a/core/provider/source/provider_source.cpp
+++ b/core/provider/source/provider_source.cpp
@@ -33,6 +33,12 @@
 #include "filesystem.h"
 #include "tier0/icommandline.h"
 
+/* Imports */
+#if SOURCE_ENGINE < SE_ORANGEBOX
+#undef CommandLine
+DLL_IMPORT ICommandLine *CommandLine();
+#endif
+
 #if SOURCE_ENGINE >= SE_ORANGEBOX
 void LocalCommand_Meta(const CCommand& args);
 #else


### PR DESCRIPTION
# Description

Fixes #252 

The Ship's tier0 DLL doesn't export `CommandLine_Tier0`.

This might not be the best fix since these changes needs to be copied to any file using `tier0/icommandline.h`.
At the moment there are only two files.