### PR TITLE
Correct memory size calculation for modules on linux

### DIFF
--- a/loader/utility.cpp
+++ b/loader/utility.cpp
@@ -519,6 +519,10 @@ mm_GetLibraryInfo(const void *libPtr, DynLibInfo &lib)
 			}
 		}
 	}
+	if (minAddr > maxAddr)
+	{
+		return false;
+	}
 	lib.memorySize = maxAddr - minAddr;
 
 #elif defined __APPLE__


### PR DESCRIPTION
Saw the conversation happening on discord about this specific change, as well as #253 and #251.

While the solution given isn't correct, @azzyr remains right in their statement that we're just lucky that `.rodata` happens to be found within the aligned page's size. I'm not at all familiar with how modules are loaded on linux, however a quick read of the manual on [elf](https://www.man7.org/linux/man-pages/man5/elf.5.html) does tell us that `PT_LOAD` segments will have as final size in memory `p_memsz` which can be 0 (for `PT_LOAD` segments that end up not taking any place in memory).

I'm not quite sure why the #251 PR as well as the original code both stubbordingly limit their calculation to one `PT_LOAD` segment without really explaining the reasoning behind. The module size will *at least* be the addition of all `PT_LOAD`'s `p_memsz`, so let's do just that.