### PR TITLE
Make GenBuffer allocator a pointer

### DIFF
--- a/core/sourcehook/sh_asm.h
+++ b/core/sourcehook/sh_asm.h
@@ -9,14 +9,12 @@ namespace SourceHook
 	{
 		class GenBuffer
 		{
-			static CPageAlloc ms_Allocator;
-
 			unsigned char *m_pData;
 			std::uint32_t m_Size;
 			std::uint32_t m_AllocatedSize;
-
+			CPageAlloc* ms_Allocator;
 		public:
-			GenBuffer() : m_pData(NULL), m_Size(0), m_AllocatedSize(0)
+			GenBuffer(CPageAlloc* allocator) : m_pData(NULL), m_Size(0), m_AllocatedSize(0), ms_Allocator(allocator)
 			{
 			}
 			~GenBuffer()
@@ -47,8 +45,8 @@ namespace SourceHook
 						m_AllocatedSize = 64;
 
 					unsigned char *newBuf;
-					newBuf = reinterpret_cast<unsigned char*>(ms_Allocator.Alloc(m_AllocatedSize));
-					ms_Allocator.SetRW(newBuf);
+					newBuf = reinterpret_cast<unsigned char*>(ms_Allocator->Alloc(m_AllocatedSize));
+					ms_Allocator->SetRW(newBuf);
 					if (!newBuf)
 					{
 						SH_ASSERT(0, ("bad_alloc: couldn't allocate 0x%08X bytes of memory\n", m_AllocatedSize));
@@ -58,9 +56,9 @@ namespace SourceHook
 					memcpy((void*)newBuf, (const void*)m_pData, m_Size);
 					if (m_pData)
 					{
-						ms_Allocator.SetRE(reinterpret_cast<void*>(m_pData));
-						ms_Allocator.SetRW(newBuf);
-						ms_Allocator.Free(reinterpret_cast<void*>(m_pData));
+						ms_Allocator->SetRE(reinterpret_cast<void*>(m_pData));
+						ms_Allocator->SetRW(newBuf);
+						ms_Allocator->Free(reinterpret_cast<void*>(m_pData));
 					}
 					m_pData = newBuf;
 				}
@@ -83,7 +81,7 @@ namespace SourceHook
 			void clear()
 			{
 				if (m_pData)
-					ms_Allocator.Free(reinterpret_cast<void*>(m_pData));
+					ms_Allocator->Free(reinterpret_cast<void*>(m_pData));
 				m_pData = NULL;
 				m_Size = 0;
 				m_AllocatedSize = 0;
@@ -91,7 +89,7 @@ namespace SourceHook
 
 			void SetRE()
 			{
-				ms_Allocator.SetRE(reinterpret_cast<void*>(m_pData));
+				ms_Allocator->SetRE(reinterpret_cast<void*>(m_pData));
 			}
 
 			operator void *()

--- a/core/sourcehook/sh_asm_x86_64.h
+++ b/core/sourcehook/sh_asm_x86_64.h
@@ -273,6 +273,8 @@ namespace SourceHook
 		
 		class x64JitWriter : public GenBuffer {
 		public:
+			x64JitWriter(CPageAlloc* alloc) : GenBuffer(alloc) {}
+
 			void breakpoint() {
 				this->write_ubyte(0xCC);
 			}

--- a/core/sourcehook/sourcehook_hookmangen.cpp
+++ b/core/sourcehook/sourcehook_hookmangen.cpp
@@ -44,9 +44,9 @@ namespace SourceHook
 	namespace Impl
 	{
 		// *********************************** class GenContextContainer
-		CHookManagerAutoGen::CHookManagerAutoGen(ISourceHook *pSHPtr) : m_pSHPtr(pSHPtr), ms_Allocator(16) { }
+		CHookManagerAutoGen::CHookManagerAutoGen(ISourceHook *pSHPtr) : m_pSHPtr(pSHPtr) { m_Allocator = new CPageAlloc(16); }
 
-		CHookManagerAutoGen::~CHookManagerAutoGen() { }
+		CHookManagerAutoGen::~CHookManagerAutoGen() { m_Contexts.clear(); delete m_Allocator; }
 
 		int CHookManagerAutoGen::GetIfaceVersion()
 		{
@@ -76,7 +76,7 @@ namespace SourceHook
 			// Not found yet -> new one
 			StoredContext sctx;
 			sctx.m_RefCnt = 1;
-			sctx.m_GenContext = std::make_unique<SHGenContext>(proto, vtbl_offs, vtbl_idx, m_pSHPtr, &ms_Allocator);
+			sctx.m_GenContext = std::make_unique<SHGenContext>(proto, vtbl_offs, vtbl_idx, m_pSHPtr, m_Allocator);
 
 			auto pubFunc = sctx.m_GenContext->GetPubFunc();
 			if (pubFunc != nullptr)

--- a/core/sourcehook/sourcehook_hookmangen.cpp
+++ b/core/sourcehook/sourcehook_hookmangen.cpp
@@ -41,12 +41,10 @@ typedef SourceHook::Impl::GenContext SHGenContext;
 
 namespace SourceHook
 {
-	CPageAlloc Asm::GenBuffer::ms_Allocator(16);
-	
 	namespace Impl
 	{
 		// *********************************** class GenContextContainer
-		CHookManagerAutoGen::CHookManagerAutoGen(ISourceHook *pSHPtr) : m_pSHPtr(pSHPtr) { }
+		CHookManagerAutoGen::CHookManagerAutoGen(ISourceHook *pSHPtr) : m_pSHPtr(pSHPtr), ms_Allocator(16) { }
 
 		CHookManagerAutoGen::~CHookManagerAutoGen() { }
 
@@ -78,7 +76,7 @@ namespace SourceHook
 			// Not found yet -> new one
 			StoredContext sctx;
 			sctx.m_RefCnt = 1;
-			sctx.m_GenContext = std::make_unique<SHGenContext>(proto, vtbl_offs, vtbl_idx, m_pSHPtr);
+			sctx.m_GenContext = std::make_unique<SHGenContext>(proto, vtbl_offs, vtbl_idx, m_pSHPtr, &ms_Allocator);
 
 			auto pubFunc = sctx.m_GenContext->GetPubFunc();
 			if (pubFunc != nullptr)

--- a/core/sourcehook/sourcehook_hookmangen.h
+++ b/core/sourcehook/sourcehook_hookmangen.h
@@ -63,7 +63,7 @@ namespace SourceHook
 			};
 			std::list<StoredContext> m_Contexts;
 			ISourceHook *m_pSHPtr;
-			CPageAlloc ms_Allocator;
+			CPageAlloc *m_Allocator;
 
 		public:
 			CHookManagerAutoGen(ISourceHook *pSHPtr);

--- a/core/sourcehook/sourcehook_hookmangen.h
+++ b/core/sourcehook/sourcehook_hookmangen.h
@@ -63,6 +63,7 @@ namespace SourceHook
 			};
 			std::list<StoredContext> m_Contexts;
 			ISourceHook *m_pSHPtr;
+			CPageAlloc ms_Allocator;
 
 		public:
 			CHookManagerAutoGen(ISourceHook *pSHPtr);

--- a/core/sourcehook/sourcehook_hookmangen_x86.cpp
+++ b/core/sourcehook/sourcehook_hookmangen_x86.cpp
@@ -48,9 +48,9 @@ namespace SourceHook
 			return static_cast<jit_uint32_t>(size);
 		}
 
-		GenContext::GenContext(const ProtoInfo *proto, int vtbl_offs, int vtbl_idx, ISourceHook *pSHPtr)
+		GenContext::GenContext(const ProtoInfo *proto, int vtbl_offs, int vtbl_idx, ISourceHook *pSHPtr, CPageAlloc* allocator)
 			: m_GeneratedPubFunc(NULL), m_OrigProto(proto), m_Proto(proto), m_VtblOffs(vtbl_offs),
-			  m_VtblIdx(vtbl_idx), m_SHPtr(pSHPtr), m_pHI(NULL), m_HookfuncVfnptr(NULL), m_RegCounter(0)
+			  m_VtblIdx(vtbl_idx), m_SHPtr(pSHPtr), m_HookFunc(allocator), m_PubFunc(allocator), m_pHI(NULL), m_HookfuncVfnptr(NULL), m_RegCounter(0)
 		{
 			m_pHI = new void*;
 			m_HookfuncVfnptr = new void*;

--- a/core/sourcehook/sourcehook_hookmangen_x86.h
+++ b/core/sourcehook/sourcehook_hookmangen_x86.h
@@ -1715,7 +1715,7 @@ namespace SourceHook
 			HookManagerPubFunc Generate();
 		public:
 			// Level 1 -> Public interface
-			GenContext(const ProtoInfo *proto, int vtbl_offs, int vtbl_idx, ISourceHook *pSHPtr);
+			GenContext(const ProtoInfo *proto, int vtbl_offs, int vtbl_idx, ISourceHook *pSHPtr, CPageAlloc* allocator);
 			virtual ~GenContext();
 
 			virtual bool Equal(const CProto &proto, int vtbl_offs, int vtbl_idx) override;

--- a/core/sourcehook/sourcehook_hookmangen_x86_64.cpp
+++ b/core/sourcehook/sourcehook_hookmangen_x86_64.cpp
@@ -101,20 +101,9 @@ namespace SourceHook
 			MSVC_ONLY(jit.add(rsp, 40));
 		}
 
-		x64GenContext::x64GenContext()
-			: m_GeneratedPubFunc(nullptr), m_VtblOffs(0),
-			  m_VtblIdx(666), m_SHPtr((ISourceHook*)0x1122334455667788), m_pHI(nullptr), m_HookfuncVfnptr(nullptr), m_HookFunc_FrameOffset(0), m_HookFunc_FrameVarsSize(0) {
-			m_pHI = new void*;
-			*m_pHI = (void*)0x77777777;
-			m_HookfuncVfnptr = new void*;
-			m_BuiltPI = new ProtoInfo;
-			m_BuiltPI_Params = nullptr;
-			m_BuiltPI_Params2 = nullptr;
-		}
-
-		x64GenContext::x64GenContext(const ProtoInfo *proto, int vtbl_offs, int vtbl_idx, ISourceHook *pSHPtr)
+		x64GenContext::x64GenContext(const ProtoInfo *proto, int vtbl_offs, int vtbl_idx, ISourceHook *pSHPtr, CPageAlloc* allocator)
 			: m_GeneratedPubFunc(nullptr), m_OrigProto(proto), m_Proto(proto), m_VtblOffs(vtbl_offs),
-			  m_VtblIdx(vtbl_idx), m_SHPtr(pSHPtr), m_pHI(nullptr), m_HookfuncVfnptr(nullptr), m_HookFunc_FrameOffset(0), m_HookFunc_FrameVarsSize(0)
+			  m_VtblIdx(vtbl_idx), m_SHPtr(pSHPtr), m_HookFunc(allocator), m_PubFunc(allocator), m_pHI(nullptr), m_HookfuncVfnptr(nullptr), m_HookFunc_FrameOffset(0), m_HookFunc_FrameVarsSize(0)
 		{
 			m_pHI = new void*;
 			*m_pHI = (void*)0x77777777; // Magic number for debugging

--- a/core/sourcehook/sourcehook_hookmangen_x86_64.h
+++ b/core/sourcehook/sourcehook_hookmangen_x86_64.h
@@ -23,8 +23,7 @@ namespace SourceHook
 		class x64GenContext : public IGenContext
 		{
 		public:
-			x64GenContext();
-			x64GenContext(const ProtoInfo *proto, int vtbl_offs, int vtbl_idx, ISourceHook *pSHPtr);
+			x64GenContext(const ProtoInfo *proto, int vtbl_offs, int vtbl_idx, ISourceHook *pSHPtr, CPageAlloc* allocator);
 			virtual ~x64GenContext();
 
 			virtual bool Equal(const CProto &proto, int vtbl_offs, int vtbl_idx) override;


### PR DESCRIPTION
Due to nature of GenBuffer allocator, there's a possibility for `static CPageAlloc ms_Allocator` to go out of scope before the hook manager does. This creates a scenario of use after free, which is probably (but didnt verify) the following crash : alliedmodders/sourcemod#1913