### PR TITLE
Fix force_unload to perform a forced unload

### DIFF
--- a/core/metamod_console.cpp
+++ b/core/metamod_console.cpp
@@ -566,7 +566,7 @@ bool Command_Meta(IMetamodSourceCommandInfo *info)
 				int id = atoi(info->GetArg(2));
 				char error[255]={0};
 
-				if (!g_PluginMngr.Unload(id, false, error, sizeof(error)))
+				if (!g_PluginMngr.Unload(id, true, error, sizeof(error)))
 				{
 					CONMSG("Force unload failed: %s\n", error);
 					return true;


### PR DESCRIPTION
﻿## Summary

Fix `meta force_unload` so it actually performs a forced unload.

## Bug

`meta force_unload` was routing through the same non-forced path as `meta unload` by calling `g_PluginMngr.Unload(id, false, ...)`, so plugins that refused a normal unload would also refuse `force_unload`.

## Fix

Pass `force = true` from the `meta force_unload` console command while leaving `meta unload` unchanged.

## Validation

- Verified the plugin manager unload path uses the flag in `pl->m_API->Unload(error, maxlen) || force`.
- Built the Metamod target locally for `episode1` on Windows after checking out the required SDK.
- Manual verification for runtime behavior:
  1. load a plugin that refuses normal unload
  2. confirm `meta unload <id>` fails
  3. confirm `meta force_unload <id>` succeeds
