### PR TITLE
Fix the standalone SourceHook test build

### DIFF
--- a/core/sourcehook/sh_memory.h
+++ b/core/sourcehook/sh_memory.h
@@ -296,7 +296,9 @@ namespace SourceHook
 			{
 				// FreeBSD /proc/curproc/map -> parse
 				// 0x804800 0x805500 13 15 0xc6e18960 r-x 21 0x0 COW NC vnode
-				long rlower, rupper;
+				// Unsigned, both to match the %lx these are scanned with and to
+				// compare against lower/upper without a signed conversion.
+				unsigned long rlower, rupper;
 				while (fscanf(pF, "0x%lx 0x%lx", &rlower, &rupper) != EOF)
 				{
 					// Check whether we're IN THERE!

--- a/core/sourcehook/sourcehook_impl.h
+++ b/core/sourcehook/sourcehook_impl.h
@@ -215,7 +215,16 @@ namespace SourceHook
 
 		struct CHookContext : IHookContext
 		{
-			CHookContext() : m_CleanupTask(NULL)
+			// Every member, not just the cleanup task: SetIgnoreHooks pushes a
+			// context with only m_State filled in, and SetupHookLoop writes the
+			// rest before reading them, which the compiler cannot see. Leaving
+			// them indeterminate costs nothing to fix and stops a future reader
+			// of an Ignore context from picking up garbage.
+			CHookContext()
+				: m_State(State_Born), pVfnPtr(NULL), pIface(NULL), pStatus(NULL),
+				  pPrevRes(NULL), pCurRes(NULL), pThisPtr(NULL), pOrigRet(NULL),
+				  pOverrideRet(NULL), pIfacePtr(NULL), m_CallOrig(false),
+				  m_CleanupTask(NULL)
 			{
 			}
 

--- a/core/sourcehook/test/Makefile
+++ b/core/sourcehook/test/Makefile
@@ -5,11 +5,19 @@ OPT_FLAGS = -O3 -funroll-loops -s -pipe
 DEBUG_FLAGS = -g -ggdb3
 CPP = gcc
 LINK = -lstdc++
-INCLUDE = -I. -I..
+INCLUDE = -I. -I.. -I../..
 MAX_PARAMS=20
 
 BINARY = sourcehook_test
-OBJECTS = main.cpp sourcehook.cpp sourcehook_hookmangen.cpp sourcehook_impl_chookmaninfo.cpp sourcehook_impl_chookidman.cpp sourcehook_impl_cproto.cpp sourcehook_impl_cvfnptr.cpp $(shell ls -t test*.cpp)
+# The hook generator is split per architecture; pick what the compiler is
+# actually targeting, so -m32 on an x86_64 host still resolves correctly.
+HOOKMANGEN_ARCH := $(if $(shell echo | $(CPP) $(CFLAGS) -E -dM - 2>/dev/null | grep __x86_64__),sourcehook_hookmangen_x86_64.cpp,sourcehook_hookmangen_x86.cpp)
+
+ifeq ($(HOOKMANGEN_ARCH),sourcehook_hookmangen_x86_64.cpp)
+  $(error The x86_64 hook generator pulls in metamod.h and the HL2SDK, which this standalone build does not have. Build 32-bit, e.g. CPP="gcc -m32" or CPP=i686-linux-gnu-gcc, which is also the only configuration AMBuilder builds these tests in)
+endif
+
+OBJECTS = main.cpp sourcehook.cpp sourcehook_hookmangen.cpp $(HOOKMANGEN_ARCH) sourcehook_impl_chookmaninfo.cpp sourcehook_impl_chookidman.cpp sourcehook_impl_cproto.cpp sourcehook_impl_cvfnptr.cpp $(shell ls -t test*.cpp)
 HEADERS = ../sh_list.h ../sh_tinyhash.h ../sh_memory.h ../sh_string.h ../sh_vector.h ../sourcehook_impl.h ../FastDelegate.h ../sourcehook.h ../sh_memfuncinfo.h ../sh_pagealloc.h
 
 ifeq "$(DEBUG)" "true"
@@ -22,7 +30,11 @@ endif
 
 CFLAGS += -Wall -Wno-non-virtual-dtor
 # Also, enable SH_ASSERT
-CFLAGS += -DSH_DEBUG
+# SourceHook swaps vtable entries out from under the compiler; GCC's
+# devirtualisation assumes it cannot happen (see issue #51). AMBuilder
+# turns it off from gcc-4.9 on, and so must this.
+CFLAGS += -fno-devirtualize
+CFLAGS += -DSH_DEBUG -DSOURCEHOOK_TESTS
 
 OBJ_LINUX := $(OBJECTS:%.cpp=$(BIN_DIR)/%.o)
 	
@@ -48,6 +60,7 @@ all:
 	mkdir -p $(BIN_DIR)
 	ln -sf ../sourcehook.cpp
 	ln -sf ../sourcehook_hookmangen.cpp
+	ln -sf ../$(HOOKMANGEN_ARCH)
 	ln -sf ../sourcehook_impl_chookidman.cpp
 	ln -sf ../sourcehook_impl_chookmaninfo.cpp
 	ln -sf ../sourcehook_impl_cproto.cpp
@@ -56,6 +69,7 @@ all:
 	rm -f $(BINARY)
 	rm -f sourcehook.cpp
 	rm -f sourcehook_hookmangen.cpp
+	rm -f $(HOOKMANGEN_ARCH)
 	rm -f sourcehook_impl_chookidman.cpp
 	rm -f sourcehook_impl_chookmaninfo.cpp
 	rm -f sourcehook_impl_cproto.cpp


### PR DESCRIPTION
The standalone `core/sourcehook/test/Makefile` had drifted from `test/AMBuilder` far enough that it no longer linked. Since AMBuilder builds these tests for x86 only and neither CI workflow runs them, nothing noticed. Five things were missing: the architecture-specific hook generator source and its symlink, added when hookmangen was split; `SOURCEHOOK_TESTS`, without which `SH_DEBUG_LOG` pulls in `g_SHPtr` that only `core/metamod.cpp` defines; `core/` on the include path; and `-fno-devirtualize`.

That last one is worth calling out on its own. Without it the suite builds and then fails ten of its sixteen tests and segfaults, which reads as SourceHook being broken rather than as a missing flag — devirtualisation assumes the vtable entries SourceHook swaps cannot change. With all five the suite is green at 16/16, on both `CPP="gcc -m32"` and `CPP=i686-linux-gnu-gcc`.

x86_64 stays out, matching AMBuilder: that generator includes `metamod.h` and the HL2SDK, which a standalone build does not have. Building natively on x86_64 now says so instead of failing on a missing `interface.h`.

Two warnings the revived build surfaced are fixed in their own commits. `CHookContext`'s constructor set `m_CleanupTask` and left eleven members indeterminate; nothing reads them today, since `SetupHookLoop` writes them before use, and it costs nothing on the dispatch path because contexts there come from `CStack::make_next()` out of an already-constructed sector. `ModuleInMemory` scanned `/proc/curproc/map` into `long` while using `%lx` and comparing against unsigned values, which the Linux branch five lines above already gets right; behaviour is unchanged, and that branch does not run on Linux so it is compile-tested only.

Not related to #191, which is about `orig_ret` in `SH_SETUPCALLS`. That one looks like it needs initialising a return value on every hooked call, so it seemed worth leaving to you rather than paying for it on the dispatch path.
