### PR TITLE
Make the x86_64 hook manager generator work on Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ build/
 build-*/
 obj-*/
 .gdb_history
+
+.vs/*
+.vscode/*

--- a/core/AMBuilder
+++ b/core/AMBuilder
@@ -29,7 +29,7 @@ for sdk_target in MMS.sdk_targets:
 
   if binary.compiler.target.arch == 'x86':
     binary.sources += ['sourcehook/sourcehook_hookmangen_x86.cpp']
-  elif binary.compiler.target.arch == 'x86_64' and binary.compiler.target.platform != 'linux':
+  elif binary.compiler.target.arch == 'x86_64':
     binary.sources += ['sourcehook/sourcehook_hookmangen_x86_64.cpp']
   nodes = builder.Add(binary)
   MMS.binaries += [nodes]

--- a/core/metamod.cpp
+++ b/core/metamod.cpp
@@ -124,9 +124,7 @@ static ConVar *mm_basedir = NULL;
 static CreateInterfaceFn engine_factory = NULL;
 static CreateInterfaceFn physics_factory = NULL;
 static CreateInterfaceFn filesystem_factory = NULL;
-#if !defined( __amd64__ )
 static CHookManagerAutoGen g_SH_HookManagerAutoGen(&g_SourceHook);
-#endif
 static META_RES last_meta_res;
 static IServerPluginCallbacks *vsp_callbacks = NULL;
 static bool were_plugins_loaded = false;
@@ -1035,7 +1033,6 @@ void *MetamodSource::MetaFactory(const char *iface, int *ret, PluginId *id)
 		}
 		return static_cast<void *>(static_cast<ISmmPluginManager *>(&g_PluginMngr));
 	}
-#if !defined( __amd64__ )
 	else if (strcmp(iface, MMIFACE_SH_HOOKMANAUTOGEN) == 0)
 	{
 		if (ret)
@@ -1044,7 +1041,7 @@ void *MetamodSource::MetaFactory(const char *iface, int *ret, PluginId *id)
 		}
 		return static_cast<void *>(static_cast<SourceHook::IHookManagerAutoGen *>(&g_SH_HookManagerAutoGen));
 	}
-#endif
+
 	CPluginManager::CPlugin *pl;
 	List<IMetamodListener *>::iterator event;
 	IMetamodListener *api;

--- a/core/sourcehook/generate/sourcehook.hxx
+++ b/core/sourcehook/generate/sourcehook.hxx
@@ -208,7 +208,7 @@ namespace SourceHook
 			// SH tries to auto-detect these
 			// If you want to override SH's auto-detection, pass them in yourself
 			PassFlag_RetMem		= (1<<6),		/**< Object is returned in memory (through hidden first param */
-			PassFlag_RetReg		= (1<<7)		/**< Object is returned in EAX(:EDX)/RAX(x86_64) */
+			PassFlag_RetReg		= (1<<7)		/**< Object is returned in EAX(:EDX) (x86) / RAX(:RDX)/XMM0(:XMM1) (x86_64) */
 		};
 
 		size_t size;			//!< Size of the data being passed

--- a/core/sourcehook/sh_asm_x86_64.h
+++ b/core/sourcehook/sh_asm_x86_64.h
@@ -581,6 +581,10 @@ namespace SourceHook
 			void retn() {
 				this->write_ubyte(0xC3);
 			}
+
+			void leave() {
+				this->write_ubyte(0xC9);
+			}
 		};
 	}
 }

--- a/core/sourcehook/sourcehook.h
+++ b/core/sourcehook/sourcehook.h
@@ -207,7 +207,7 @@ namespace SourceHook
 			// The following two flags are only relevant for byval return types.
 			// SH tries to auto-detect these
 			// If you want to override SH's auto-detection, pass them in yourself
-			PassFlag_RetMem		= (1<<6),		/**< Object is returned in memory (through hidden first param */
+			PassFlag_RetMem		= (1<<6),		/**< Object is returned in memory (through hidden first param) */
 			PassFlag_RetReg		= (1<<7)		/**< Object is returned in EAX(:EDX)/RAX(x86_64) */
 		};
 

--- a/core/sourcehook/sourcehook.h
+++ b/core/sourcehook/sourcehook.h
@@ -208,7 +208,7 @@ namespace SourceHook
 			// SH tries to auto-detect these
 			// If you want to override SH's auto-detection, pass them in yourself
 			PassFlag_RetMem		= (1<<6),		/**< Object is returned in memory (through hidden first param) */
-			PassFlag_RetReg		= (1<<7)		/**< Object is returned in EAX(:EDX)/RAX(x86_64) */
+			PassFlag_RetReg		= (1<<7)		/**< Object is returned in EAX(:EDX) (x86) / RAX(:RDX)/XMM0(:XMM1) (x86_64) */
 		};
 
 		size_t size;			//!< Size of the data being passed

--- a/core/sourcehook/sourcehook_hookmangen.cpp
+++ b/core/sourcehook/sourcehook_hookmangen.cpp
@@ -18,7 +18,7 @@
 #include <stdio.h>
 #include "sourcehook_impl.h"
 #include "sourcehook_hookmangen.h"
-#if defined( PLATFORM_64BITS ) && !defined( _LINUX )
+#if defined( PLATFORM_64BITS )
 #include "sourcehook_hookmangen_x86_64.h"
 typedef SourceHook::Impl::x64GenContext SHGenContext;
 #else
@@ -61,9 +61,6 @@ namespace SourceHook
 
 		HookManagerPubFunc CHookManagerAutoGen::MakeHookMan(const ProtoInfo *proto, int vtbl_offs, int vtbl_idx)
 		{
-#if defined( PLATFORM_64BITS ) && defined( _LINUX )
-			return nullptr;
-#else
 			CProto mproto(proto);
 			for (auto iter = m_Contexts.begin(); iter != m_Contexts.end(); ++iter)
 			{
@@ -85,7 +82,6 @@ namespace SourceHook
 				m_Contexts.emplace_back(std::move(sctx));
 			}
 			return pubFunc;
-#endif
 		}
 
 		void CHookManagerAutoGen::ReleaseHookMan(HookManagerPubFunc pubFunc)

--- a/core/sourcehook/sourcehook_hookmangen_x86.cpp
+++ b/core/sourcehook/sourcehook_hookmangen_x86.cpp
@@ -96,10 +96,10 @@ namespace SourceHook
 			m_BuiltPI->retPassInfo2.pAssignOperator = m_Proto.GetRet().pAssignOperator;
 
 			if (m_BuiltPI_Params)
-				delete m_BuiltPI_Params;
+				delete [] m_BuiltPI_Params;
 			m_BuiltPI_Params = new PassInfo[m_BuiltPI->numOfParams + 1];
 			if (m_BuiltPI_Params2)
-				delete m_BuiltPI_Params2;
+				delete [] m_BuiltPI_Params2;
 			m_BuiltPI_Params2 = new PassInfo::V2Info[m_BuiltPI->numOfParams + 1];
 
 			m_BuiltPI_Params[0].size = 1;			// Version 1

--- a/core/sourcehook/sourcehook_hookmangen_x86_64.cpp
+++ b/core/sourcehook/sourcehook_hookmangen_x86_64.cpp
@@ -73,6 +73,8 @@ namespace SourceHook
 
 			// Shadow space
 			MSVC_ONLY(jit.sub(rsp, 40));
+			// We need to keep it aligned to 16 bytes on Linux too...
+			GCC_ONLY(jit.sub(rsp, 8));
 
 			MSVC_ONLY(jit.mov(rcx, reinterpret_cast<std::uint64_t>(provider)));
 			GCC_ONLY(jit.mov(rdi, reinterpret_cast<std::uint64_t>(provider)));
@@ -96,6 +98,8 @@ namespace SourceHook
 			jit.mov(rax, rax(sizeof(void*) * mfi2.vtblindex));
 			jit.call(rax);
 
+			// Free Linux stack alignment
+			GCC_ONLY(jit.add(rsp, 8));
 			// Free shadow space
 			MSVC_ONLY(jit.add(rsp, 40));
 		}
@@ -525,6 +529,8 @@ namespace SourceHook
 
 				// Shadow space
 				MSVC_ONLY(m_HookFunc.sub(rsp, 40));
+				// We need to keep it aligned to 16 bytes on Linux too...
+				GCC_ONLY(m_HookFunc.sub(rsp, 8));
 				for (int i = 0; i < 3; i++) {
 					// First param is this
 					MSVC_ONLY(m_HookFunc.lea(rcx, rbp(v_ret_vals[i])));
@@ -533,6 +539,8 @@ namespace SourceHook
 					m_HookFunc.mov(r8, reinterpret_cast<std::uint64_t>(retInfo.pDtor));
 					m_HookFunc.call(r8);
 				}
+				// Free Linux stack alignment
+				GCC_ONLY(m_HookFunc.add(rsp, 8));
 				// Free shadow space
 				MSVC_ONLY(m_HookFunc.add(rsp, 40));
 			}
@@ -576,6 +584,7 @@ namespace SourceHook
 
 			// Allocate the necessary stack space
 			MSVC_ONLY(m_HookFunc.sub(rsp, 88)); // shadow space (32 bytes) + 6 stack arguments (48 bytes) + 8 bytes
+			// TODO: GCC_ONLY(m_HookFunk.sub(rsp, 8 + ?));
 
 			// 1st parameter (this)
 			GCC_ONLY(m_HookFunc.mov(rdi, reinterpret_cast<std::uintptr_t>(m_SHPtr)));
@@ -636,6 +645,7 @@ namespace SourceHook
 			// Store the return value
 			m_HookFunc.mov(rbp(v_pContext), rax);
 
+			// TODO: GCC_ONLY(m_HookFunc.add(rsp, 8 + ?));
 			// Restore the rsp value
 			MSVC_ONLY(m_HookFunc.add(rsp, 88));
 		}
@@ -710,6 +720,8 @@ namespace SourceHook
 
 			// Shadow space 32 bytes + 8 bytes
 			MSVC_ONLY(m_HookFunc.sub(rsp, 40));
+			// We need to keep it aligned to 16 bytes on Linux too...
+			GCC_ONLY(m_HookFunc.sub(rsp, 8));
 
 			GCC_ONLY(m_HookFunc.mov(rdi, rbp(v_pContext)));
 			MSVC_ONLY(m_HookFunc.mov(rcx, rbp(v_pContext)));
@@ -718,6 +730,9 @@ namespace SourceHook
 			// store into iter
 			m_HookFunc.mov(rbp(v_iter), rax);
 
+			// Free Linux stack alignment
+			GCC_ONLY(m_HookFunc.add(rsp, 8));
+			// Free shadow space
 			MSVC_ONLY(m_HookFunc.add(rsp, 40));
 
 			// null check iter
@@ -765,6 +780,8 @@ namespace SourceHook
 
 				// Shadow space 32 bytes + 8 bytes
 				MSVC_ONLY(m_HookFunc.sub(rsp, 40));
+				// We need to keep it aligned to 16 bytes on Linux too...
+				GCC_ONLY(m_HookFunc.sub(rsp, 8));
 
 				m_HookFunc.mov(rax, rbp(v_pContext));
 				m_HookFunc.mov(rax, rax()); // *this (vtable)
@@ -774,6 +791,8 @@ namespace SourceHook
 				MSVC_ONLY(m_HookFunc.mov(rcx, rbp(v_pContext)));
 				m_HookFunc.call(rax); // pContext->GetOverrideRetPtr()
 
+				// Free Linux stack alignment
+				GCC_ONLY(m_HookFunc.add(rsp, 8));
 				MSVC_ONLY(m_HookFunc.add(rsp, 40));
 
 				// *reinterpret_cast<my_rettype*>(pContext->GetOverrideRetPtr()) = plugin_ret;
@@ -791,6 +810,8 @@ namespace SourceHook
 					{
 						// Shadow space 32 bytes + 8 bytes
 						MSVC_ONLY(m_HookFunc.sub(rsp, 40));
+						// We need to keep it aligned to 16 bytes on Linux too...
+						GCC_ONLY(m_HookFunc.sub(rsp, 8));
 
 						// 1st parameter (this)
 						GCC_ONLY(m_HookFunc.mov(rdi, rax));
@@ -804,6 +825,9 @@ namespace SourceHook
 						m_HookFunc.mov(rax, reinterpret_cast<std::uint64_t>(retInfo.pAssignOperator));
 						m_HookFunc.call(rax);
 
+						// Free Linux stack alignment
+						GCC_ONLY(m_HookFunc.add(rsp, 8));
+						// Free shadow space
 						MSVC_ONLY(m_HookFunc.add(rsp, 40));
 					}
 					else
@@ -864,6 +888,8 @@ namespace SourceHook
 
 			// Shadow space 32 bytes + 8 bytes
 			MSVC_ONLY(m_HookFunc.sub(rsp, 40));
+			// We need to keep it aligned to 16 bytes on Linux too...
+			GCC_ONLY(m_HookFunc.sub(rsp, 8));
 
 			m_HookFunc.mov(rax, rbp(v_pContext));
 
@@ -876,6 +902,9 @@ namespace SourceHook
 
 			m_HookFunc.call(rax); // pContext->ShouldCallOrig()
 
+			// Free Linux stack alignment
+			GCC_ONLY(m_HookFunc.add(rsp, 8));
+			// Free shadow space
 			MSVC_ONLY(m_HookFunc.add(rsp, 40));
 
 			// Don't have the lower register yet, so this will do for now
@@ -915,6 +944,8 @@ namespace SourceHook
 					{
 						// Shadow space 32 bytes + 8 bytes
 						MSVC_ONLY(m_HookFunc.sub(rsp, 40));
+						// We need to keep it aligned to 16 bytes on Linux too...
+						GCC_ONLY(m_HookFunc.sub(rsp, 8));
 
 						// 1st parameter (this)
 						GCC_ONLY(m_HookFunc.lea(rdi, rbp(v_orig_ret)));
@@ -928,6 +959,9 @@ namespace SourceHook
 						m_HookFunc.mov(rax, reinterpret_cast<std::uint64_t>(retInfo.pAssignOperator));
 						m_HookFunc.call(rax);
 
+						// Free Linux stack alignment
+						GCC_ONLY(m_HookFunc.add(rsp, 8));
+						// Free shadow space
 						MSVC_ONLY(m_HookFunc.add(rsp, 40));
 					}
 					else
@@ -1201,6 +1235,8 @@ namespace SourceHook
 
 			// Shadow space 32 bytes + 8 bytes
 			MSVC_ONLY(m_HookFunc.sub(rsp, 40));
+			// We need to keep it aligned to 16 bytes on Linux too...
+			GCC_ONLY(m_HookFunc.sub(rsp, 8));
 
 			// 1st parameter (this)
 			GCC_ONLY(m_HookFunc.mov(rdi, rbp(v_pContext)));
@@ -1208,6 +1244,9 @@ namespace SourceHook
 
 			m_HookFunc.call(rax);
 
+			// Free Linux stack alignment
+			GCC_ONLY(m_HookFunc.add(rsp, 8));
+			// Free shadow space
 			MSVC_ONLY(m_HookFunc.add(rsp, 40));
 
 			m_HookFunc.mov(rbp(v_retptr), rax);
@@ -1243,6 +1282,8 @@ namespace SourceHook
 				{
 					// Shadow space 32 bytes + 8 bytes
 					MSVC_ONLY(m_HookFunc.sub(rsp, 40));
+					// We need to keep it aligned to 16 bytes on Linux too...
+					GCC_ONLY(m_HookFunc.sub(rsp, 8));
 
 					// 1st parameter (this)
 					GCC_ONLY(m_HookFunc.mov(rdi, rbp(v_memret_outaddr)));
@@ -1256,6 +1297,9 @@ namespace SourceHook
 					m_HookFunc.mov(rax, reinterpret_cast<std::uint64_t>(retInfo.pCopyCtor));
 					m_HookFunc.call(rax);
 
+					// Free Linux stack alignment
+					GCC_ONLY(m_HookFunc.add(rsp, 8));
+					// Free shadow space
 					MSVC_ONLY(m_HookFunc.add(rsp, 40));
 				}
 				else
@@ -1294,6 +1338,8 @@ namespace SourceHook
 
 			// Shadow space 32 bytes + 8 bytes
 			MSVC_ONLY(m_HookFunc.sub(rsp, 40));
+			// We need to keep it aligned to 16 bytes on Linux too...
+			GCC_ONLY(m_HookFunc.sub(rsp, 8));
 
 			// 1st parameter (this)
 			GCC_ONLY(m_HookFunc.mov(rdi, reinterpret_cast<std::uintptr_t>(m_SHPtr)));
@@ -1307,6 +1353,9 @@ namespace SourceHook
 			m_HookFunc.mov(rax, (*reinterpret_cast<std::uintptr_t**>(m_SHPtr))[mfi.vtblindex]);
 			m_HookFunc.call(rax);
 
+			// Free Linux stack alignment
+			GCC_ONLY(m_HookFunc.add(rsp, 8));
+			// Free shadow space
 			MSVC_ONLY(m_HookFunc.add(rsp, 40));
 		}
 
@@ -1428,6 +1477,7 @@ namespace SourceHook
 
 			// prologue
 			MSVC_ONLY(m_PubFunc.sub(rsp, 0x38)); // Shadow space 32 bytes + 2 * 8 bytes (for our parameters) + 8 bytes
+			// TODO: GCC_ONLY(m_PubFunc.sub(rsp, 8+?));
 			
 			// Unnecessary according to AMD manual (Section 3.2.2 The Stack Frame)
 			// but GCC still does it anyways, so let's do it as well
@@ -1508,6 +1558,9 @@ namespace SourceHook
 
 			// epilogue
 
+			// Free Linux stack alignment
+			// TODO: GCC_ONLY(m_HookFunc.add(rsp, 8 + ?));
+			// Free shadow space & parameter space & stack alignment
 			MSVC_ONLY(m_PubFunc.add(rsp, 0x38));
 
 			GCC_ONLY(m_PubFunc.pop(rbp));

--- a/core/sourcehook/sourcehook_hookmangen_x86_64.cpp
+++ b/core/sourcehook/sourcehook_hookmangen_x86_64.cpp
@@ -1510,7 +1510,7 @@ namespace SourceHook
 			return true;
 		}
 
-		bool x64GenContext::AutoDetectParamFlags()
+		void x64GenContext::AutoDetectParamFlags()
 		{
 		}
 

--- a/core/sourcehook/sourcehook_hookmangen_x86_64.cpp
+++ b/core/sourcehook/sourcehook_hookmangen_x86_64.cpp
@@ -1303,7 +1303,19 @@ static_assert(false, "Missing registers saving for linux");
 						//
 						//
 						// Result: we cannot detect if it should be register or memory without knowing the layout of the object.
-						return false;
+						//
+						//
+						// It doesn't seem like constructors or copy-constructors matter much.
+
+						if ((pi.flags & PassInfo::PassFlag_ODtor) != 0)
+						{
+							pi.flags |= PassInfo::PassFlag_RetMem;
+							return true;
+						}
+						else
+						{
+							return false;
+						}
 #endif
 					}
 				}

--- a/core/sourcehook/sourcehook_hookmangen_x86_64.cpp
+++ b/core/sourcehook/sourcehook_hookmangen_x86_64.cpp
@@ -14,6 +14,7 @@
 // https://defuse.ca/online-x86-assembler.htm
 // https://learn.microsoft.com/en-us/cpp/build/x64-calling-convention
 // https://refspecs.linuxbase.orgz/elf/x86_64-abi-0.99.pdf
+// SystemV AMD64 https://gitlab.com/x86-psABIs/x86-64-ABI/-/jobs/artifacts/master/raw/x86-64-ABI/abi.pdf?job=build
 
 #include <stdio.h>
 #include <string>

--- a/core/sourcehook/sourcehook_hookmangen_x86_64.cpp
+++ b/core/sourcehook/sourcehook_hookmangen_x86_64.cpp
@@ -1461,9 +1461,14 @@ namespace SourceHook
 
 						bool probablyVector = (pi.size == 12);
 
-						if (hasSpecialFunctions || tooBig || probablyVector)
+						if (hasSpecialFunctions || tooBig)
 						{
 							pi.flags |= PassInfo::PassFlag_RetMem;
+							return true;
+						}
+						else if (probablyVector)
+						{
+							pi.flags |= PassInfo::PassFlag_RetReg;
 							return true;
 						}
 						else

--- a/core/sourcehook/sourcehook_hookmangen_x86_64.cpp
+++ b/core/sourcehook/sourcehook_hookmangen_x86_64.cpp
@@ -1488,8 +1488,8 @@ namespace SourceHook
 			MSVC_ONLY(m_PubFunc.sub(rsp, 0x38)); // Shadow space 32 bytes + 2 * 8 bytes (for our parameters) + 8 bytes
 			// TODO: GCC_ONLY(m_PubFunc.sub(rsp, 8+?));
 			
-			// Unnecessary according to AMD manual (Section 3.2.2 The Stack Frame)
-			// but GCC still does it anyways, so let's do it as well
+			// Frame pointer! We like working callstacks when debugging crashes!
+			// TODO: Might mean we don't have to `sub rsp, 8`?
 			GCC_ONLY(m_PubFunc.push(rbp));
 			GCC_ONLY(m_PubFunc.mov(rbp, rsp));
 

--- a/core/sourcehook/sourcehook_hookmangen_x86_64.cpp
+++ b/core/sourcehook/sourcehook_hookmangen_x86_64.cpp
@@ -1443,7 +1443,9 @@ namespace SourceHook
 						//
 						// Result: we cannot detect if it should be register or memory without knowing the layout of the object.
 
-						if (hasSpecialFunctions)
+						bool tooBig = (pi.size > (8 * 8));
+
+						if (hasSpecialFunctions || tooBig)
 						{
 							pi.flags |= PassInfo::PassFlag_RetMem;
 							return true;

--- a/core/sourcehook/sourcehook_hookmangen_x86_64.cpp
+++ b/core/sourcehook/sourcehook_hookmangen_x86_64.cpp
@@ -238,7 +238,10 @@ namespace SourceHook
 			}
 
 			// Detect the pass flags (if they're missing) for return and parameters type
-			AutoDetectRetType();
+			if (!AutoDetectRetType())
+			{
+				return nullptr;
+			}
 			AutoDetectParamFlags();
 
 			// Calling conventions are gone on x86_64, there's only one to call all functions
@@ -1236,11 +1239,11 @@ static_assert(false, "Missing registers saving for linux");
 				&& (retInfo.flags & (PassInfo::PassFlag_ODtor | PassInfo::PassFlag_AssignOp)));
 		}
 		
-		void x64GenContext::AutoDetectRetType() {
+		bool x64GenContext::AutoDetectRetType() {
 			auto& pi = m_Proto.GetRet();
 			// Void return, ignore
 			if (pi.size == 0) {
-				return;
+				return true;
 			}
 
 			// Only relevant for byval types
@@ -1283,7 +1286,24 @@ static_assert(false, "Missing registers saving for linux");
 							pi.flags |= PassInfo::PassFlag_RetReg;
 						}
 #elif SH_COMP == SH_COMP_GCC
-static_assert(false, "Missing auto-detect type for linux!");
+						// It depends on the object layout.
+						//
+						//
+						//   typedef struct __attribute__((packed)) { char a; int b; } thing;
+						//   = memory (5 bytes)
+						//
+						//   typedef struct __attribute__((packed)) { int a; char b; } thing;
+						//   = register (5 bytes)
+						//
+						//   typedef struct __attribute__((packed)) { char a; short b; char c; } thing;
+						//   = memory (6 bytes)
+						//
+						//   typedef struct __attribute__((packed)) { char a; short b; int c; char d; } thing;
+						//   = memory (8 bytes)
+						//
+						//
+						// Result: we cannot detect if it should be register or memory without knowing the layout of the object.
+						return false;
 #endif
 					}
 				}
@@ -1294,6 +1314,7 @@ static_assert(false, "Missing auto-detect type for linux!");
 				pi.flags &= ~PassInfo::PassFlag_RetMem;
 				pi.flags |= PassInfo::PassFlag_RetReg;
 			}
+			return true;
 		}
 
 		void x64GenContext::AutoDetectParamFlags()

--- a/core/sourcehook/sourcehook_hookmangen_x86_64.cpp
+++ b/core/sourcehook/sourcehook_hookmangen_x86_64.cpp
@@ -41,6 +41,10 @@ extern SourceMM::IMetamodSourceProvider *provider;
 # define MSVC_ONLY(x)
 #endif
 
+// On Windows: this is the start of the shadow space.
+// On Linux: this is the start of the stack args.
+const std::int32_t OffsetToCallerStack = 16;
+
 using namespace SourceHook::Asm;
 
 namespace SourceHook
@@ -72,10 +76,6 @@ namespace SourceHook
 				}
 			}
 
-			// Shadow space
-			MSVC_ONLY(jit.sub(rsp, 40));
-			// We need to keep it aligned to 16 bytes on Linux too...
-			GCC_ONLY(jit.sub(rsp, 8));
 
 			MSVC_ONLY(jit.mov(rcx, reinterpret_cast<std::uint64_t>(provider)));
 			GCC_ONLY(jit.mov(rdi, reinterpret_cast<std::uint64_t>(provider)));
@@ -98,11 +98,6 @@ namespace SourceHook
 			jit.mov(rax, rax(mfi2.vtbloffs));
 			jit.mov(rax, rax(sizeof(void*) * mfi2.vtblindex));
 			jit.call(rax);
-
-			// Free Linux stack alignment
-			GCC_ONLY(jit.add(rsp, 8));
-			// Free shadow space
-			MSVC_ONLY(jit.add(rsp, 40));
 		}
 
 		x64GenContext::x64GenContext()
@@ -313,72 +308,111 @@ namespace SourceHook
 		void* x64GenContext::GenerateHookFunc()
 		{
 			const auto& retInfo = m_Proto.GetRet();
-			//m_HookFunc.breakpoint();
+			m_HookFunc.breakpoint();
 
 			// For the time being, we only consider xmm0-xmm15 registers
 			// are only used to store 64bits worth of data, despite being
 			// able to store up to 128bits
 
-			// RBP is a general purpose register on x86_64
-			// we will therefore use it on both linux and windows
-			// to refer to our space in the stack where we grew
+			// Linux uses RBP as the frame pointer while Windows mostly doesn't*.
+			// It's a good register to index stack variables so we'll still use it like a Linux frame pointer.
+			// It'll probably help Accelerator's crash-logging too (at least on Linux).
+			//
+			// *: MSVC does not support the frame pointer option (/Oy-) in x64!
+			//    alloca() and some exception handling things will use it though.
+			//    Their usage is also weird: https://stackoverflow.com/q/75722486
+
+			// Save our frame pointer.
+			// This also realigns the stack to 16 bytes.
+			m_HookFunc.push(rbp);
+			m_HookFunc.mov(rbp, rsp);
 
 			// *********** stack frame *************
 
 			// MSVC ONLY START
-			// rbp + 40                             end of shadow space
-			// rbp + 8                              start of shadow space
+			// rbp + ??                             end of stack args
+			// rbp + 48                             start of stack args
+			// rbp + 40                             shadow space 4
+			// rbp + 32                             shadow space 3
+			// rbp + 24                             shadow space 2
+			// rbp + 16                             shadow space 1
 			// MSVC ONLY END
 			//
-			// rbp - 0                              begining of (old) rsp
-			// rbp - 8                              saved old rbp value
+			// GCC ONLY START
+			// rbp + ??                             end of stack args
+			// rbp + 16                             start of stack args
+			// GCC ONLY END
+			//
+			// rbp + 8                              return address
+			// rbp - 0                              original rbp
+			// rbp - 8                              this ptr
 			// rbp - 16                             vfnptr_origentry
 			// rbp - 24                             status
 			// rbp - 32                             prev_res
 			// rbp - 40                             cur_res
 			// rbp - 48                             iter
 			// rbp - 56                             context
-			// rbp - 64                             this ptr
 			// [Non void functions:]
-			// rbp - 64 - sizeof(returntype)        original return
-			// rbp - 64 - sizeof(returntype) * 2    override return
-			// rbp - 64 - sizeof(returntype) * 3    plugin return
+			// rbp - 64                             ret ptr
+			// rbp - 72                             memret ptr
+			// rbp - 80 - sizeof(returntype)        original return
+			// rbp - 80 - sizeof(returntype) * 2    override return
+			// rbp - 80 - sizeof(returntype) * 3    plugin return
+			//
+			// - 64                                 end of unused padding
+			// - 128                                start of unused padding
+			//
+			// MSVC ONLY START
+			// - 128                                end of 80 bytes of shadow space
+			// - 208                                start of 80 bytes of shadow space
+			// MSVC ONLY END
+			//
+			// GCC ONLY START
+			// - 128                                end of stack arg copies
+			// - ???                                start of stack arg copies
+			// GCC ONLY END
 
-			const std::int8_t v_original_rbp =       AddVarToFrame(SIZE_PTR); // -8
+			const std::int8_t v_this =               AddVarToFrame(SIZE_PTR); // -8
 			const std::int8_t v_vfnptr_origentry =   AddVarToFrame(SIZE_PTR); // -16
 			const std::int8_t v_status =             AddVarToFrame(SIZE_PTR /*sizeof(META_RES)*/); // -24
 			const std::int8_t v_prev_res =           AddVarToFrame(SIZE_PTR /*sizeof(META_RES)*/); // -32
 			const std::int8_t v_cur_res =            AddVarToFrame(SIZE_PTR /*sizeof(META_RES)*/); // -40
 			const std::int8_t v_iter =               AddVarToFrame(SIZE_PTR); // -48
 			const std::int8_t v_pContext =           AddVarToFrame(SIZE_PTR); // -56
-			const std::int8_t v_this =               AddVarToFrame(SIZE_PTR); // -64
 
 			// Non void return, track the values
-			std::int32_t v_ret_ptr =      0;
-			std::int32_t v_memret_ptr =   0;
+			std::int8_t v_ret_ptr =       0;
+			std::int8_t v_memret_ptr =    0;
 			std::int32_t v_orig_ret =     0;
 			std::int32_t v_override_ret = 0;
 			std::int32_t v_plugin_ret =   0;
 			std::int32_t v_mem_ret =      0;
 			if (m_Proto.GetRet().size != 0)
 			{
-				v_ret_ptr =      AddVarToFrame(SIZE_PTR);
-				v_memret_ptr =   AddVarToFrame(SIZE_PTR);
-				v_orig_ret =     AddVarToFrame(AlignSize(GetParamStackSize(retInfo), 16)); // 16 bytes aligned
+				v_ret_ptr =      AddVarToFrame(SIZE_PTR); // -64
+				v_memret_ptr =   AddVarToFrame(SIZE_PTR); // -72
+				// Did you know that 80 is 5*16? I'm gonna be sick...
+				v_orig_ret =     AddVarToFrame(AlignSize(GetParamStackSize(retInfo), 16)); // -80 // 16 bytes aligned
 				v_override_ret = AddVarToFrame(AlignSize(GetParamStackSize(retInfo), 16));
 				v_plugin_ret =   AddVarToFrame(AlignSize(GetParamStackSize(retInfo), 16));
 				v_mem_ret =      AddVarToFrame(AlignSize(GetParamStackSize(retInfo), 16));
 			}
 
-			std::int32_t stack_frame_size = ComputeVarsSize();
+			// TODO: Only added to *maybe* prevent crashes when people fuck up their parameters.
+			//       Probably shouldn't be kept...
+			std::int32_t v_padding_after_ret = AddVarToFrame(64);
+
+#if SH_COMP == SH_COMP_MSVC
+			// Regular shadow space + 6 stack args for CallSetupHookLoop.
+			// Don't actually use this variable, just index `rsp` instead.
+			std::int32_t v_local_shadow_space = AddVarToFrame(32 + 6*8);
+#endif
+
+#if SH_COMP == SH_COMP_MSVC
+			std::int32_t stack_frame_size = AlignSize(ComputeVarsSize(), 16);
 			m_HookFunc.sub(rsp, stack_frame_size);
 
-			// Store rbp where it should be
-			m_HookFunc.mov(rsp(stack_frame_size - SIZE_PTR), rbp);
-			m_HookFunc.lea(rbp, rsp(stack_frame_size));
-
 			// MSVC ONLY - Save the registers into shadow space
-#if SH_COMP == SH_COMP_MSVC
 			const x86_64_Reg params_reg[] = { rcx, rdx, r8, r9 };
 			const x86_64_FloatReg params_floatreg[] = { xmm0, xmm1, xmm2, xmm3 };
 
@@ -386,39 +420,164 @@ namespace SourceHook
 
 			// retrieve this ptr
 			m_HookFunc.mov(rbp(v_this), params_reg[reg_index]);
-			m_HookFunc.mov(rbp(reg_index * 8 + 8), params_reg[reg_index]);
+			m_HookFunc.mov(rbp(reg_index * 8 + OffsetToCallerStack), params_reg[reg_index]);
 			reg_index++;
 
 			// Non standard return size, a ptr has been passed into rcx. Shifting all the parameters
 			if ((retInfo.flags & PassInfo::PassFlag_RetMem) == PassInfo::PassFlag_RetMem) {
-				m_HookFunc.mov(rbp(reg_index * 8 + 8), params_reg[reg_index]);
+				m_HookFunc.mov(rbp(reg_index * 8 + OffsetToCallerStack), params_reg[reg_index]);
 				m_HookFunc.mov(rbp(v_memret_ptr), params_reg[reg_index]);
 				reg_index++;
 			}
 
+			// START DEBUG HELPERS
 			m_HookFunc.mov(rax, m_Proto.GetNumOfParams());
 			m_HookFunc.mov(rax, reg_index);
+			// END DEBUG HELPERS
 			m_HookFunc.mov(rax, retInfo.size);
 
 			for (int i = 0; i < m_Proto.GetNumOfParams() && reg_index < 4; reg_index++, i++) {
 				auto& info = m_Proto.GetParam(i);
 				if (info.type == PassInfo::PassType_Float && (info.flags & PassInfo::PassFlag_ByRef) != PassInfo::PassFlag_ByRef) {
-					m_HookFunc.movsd(rbp(reg_index * 8 + 8), params_floatreg[reg_index]);
+					m_HookFunc.movsd(rbp(reg_index * 8 + OffsetToCallerStack), params_floatreg[reg_index]);
 				} else {
-					m_HookFunc.mov(rbp(reg_index * 8 + 8), params_reg[reg_index]);
+					m_HookFunc.mov(rbp(reg_index * 8 + OffsetToCallerStack), params_reg[reg_index]);
 				}
 			}
 #else
 			const x86_64_Reg params_reg[] = { rdi, rsi, rdx, rcx, r8, r9 };
+			const x86_64_FloatReg params_floatreg[] = { xmm0, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7 };
+			int num_reg = sizeof(params_reg) / sizeof(params_reg[0]);
+			int num_floatreg = sizeof(params_floatreg) / sizeof(params_floatreg[0]);
 
 			int reg_index = 0;
-		
-			m_HookFunc.mov(rbp(v_this), rdi);
-			reg_index++;
+			int floatreg_index = 0;
 
+			// Retmem is in RDI even when thiscall!
 			if ((retInfo.flags & PassInfo::PassFlag_RetMem) == PassInfo::PassFlag_RetMem) {
 				m_HookFunc.mov(rbp(v_memret_ptr), params_reg[reg_index]);
 				reg_index++;
+			}
+
+			m_HookFunc.mov(rbp(v_this), params_reg[reg_index]);
+			reg_index++;
+
+			// Linux objects can be passed
+			// - inline on the stack
+			// - unpacked into registers
+			// - as a pointer
+			// This is pretty complicated and we can't know what will happen without knowing the object layout.
+			// And we don't know the object layout...
+			//
+			// From Agner Fog's Calling conventions pdf:
+			// >Objects with inheritance, member functions, or constructors can be passed in registers [and on stack].
+			// >Objects with copy constructor, destructor, or virtual are passed by pointers.
+			//
+			// For now, we'll assume that any object passed inline on the stack can be safely copied around.
+			// This probably doesn't hold in 100% of cases but for now it's the easiest.
+			//
+			// Another option would be to fuck up our stack frame:
+			// - move all offsets and data we use like 32KiB or 64KiB deeper into the stack
+			// - `pop` the real return address off the stack and store it in the deep stack (until we need it)
+			// This would allow to use the original objects that are inlined on the stack in.
+
+			// TODO: Allow 2 floats per custom_register.
+			//       Allow 2 ints per custom_register too!
+			//       This helps with objects being unpacked into registers.
+
+			// We're going to backup ALL parameter registers.
+			std::int32_t v_sysv_floatreg = AddVarToFrame(num_floatreg * 8);
+			std::int32_t v_sysv_reg = AddVarToFrame(num_reg * 8);
+
+			auto orig_reg_index = reg_index;
+			// Next we need to figure out how must stack space for stack args...
+			std::int32_t stack_args_size = 0;
+			for (int i = 0; i < m_Proto.GetNumOfParams(); ++i) {
+				const IntPassInfo &pi = m_Proto.GetParam(i);
+
+				if (pi.type == PassInfo::PassType_Basic) {
+					if (++reg_index >= num_reg) {
+						stack_args_size += 8;
+					}
+				} else if (pi.type == PassInfo::PassType_Float) {
+					if (++floatreg_index >= num_floatreg) {
+						stack_args_size += 8;
+					}
+				} else if (pi.type == PassInfo::PassType_Object) {
+					if (pi.flags & PassInfo::PassFlag_ByRef) {
+						if (++reg_index >= num_reg) {
+							stack_args_size += 8;
+						}
+					} else {
+						stack_args_size += pi.size;
+					}
+				}
+			}
+			std::int32_t v_sysv_stack_copy = AddVarToFrame(stack_args_size);
+
+			std::int32_t stack_frame_size = AlignSize(ComputeVarsSize(), 16);
+			m_HookFunc.sub(rsp, stack_frame_size);
+
+			for (int i = 0; i < num_floatreg; i++) {
+				m_HookFunc.movsd(rbp(v_sysv_floatreg + i*8), params_floatreg[i]);
+			}
+			for (int i = 0; i < num_reg; i++) {
+				m_HookFunc.mov(rbp(v_sysv_reg + i*8), params_reg[i]);
+			}
+
+			// Now let's copy stack params!
+			reg_index = orig_reg_index;
+			floatreg_index = 0;
+			std::int32_t stack_offset = 0;
+			for (int i = 0; i < m_Proto.GetNumOfParams(); ++i) {
+				const IntPassInfo &pi = m_Proto.GetParam(i);
+
+				if (pi.type == PassInfo::PassType_Basic) {
+					if (++reg_index >= num_reg) {
+						m_HookFunc.lea(rax, rbp(OffsetToCallerStack + stack_offset));
+						m_HookFunc.mov(rax, rax());
+						m_HookFunc.mov(rsp(stack_offset), rax);
+						stack_offset += 8;
+					}
+				} else if (pi.type == PassInfo::PassType_Float) {
+					if (++floatreg_index >= num_floatreg) {
+						m_HookFunc.lea(rax, rbp(OffsetToCallerStack + stack_offset));
+						m_HookFunc.mov(rax, rax());
+						m_HookFunc.mov(rsp(stack_offset), rax);
+						stack_offset += 8;
+					}
+				} else if (pi.type == PassInfo::PassType_Object) {
+					if (pi.flags & PassInfo::PassFlag_ByRef) {
+						if (++reg_index >= num_reg) {
+							m_HookFunc.lea(rax, rbp(OffsetToCallerStack + stack_offset));
+							m_HookFunc.mov(rax, rax());
+							m_HookFunc.mov(rsp(stack_offset), rax);
+							stack_offset += 8;
+						}
+					} else {
+						if (pi.pAssignOperator || pi.pCopyCtor) {
+							// 1st parameter (this)
+							m_HookFunc.lea(rdi, rbp(OffsetToCallerStack + stack_offset));
+							// 2nd parameter (copy)
+							m_HookFunc.lea(rsi, rsp(stack_offset));
+							// Move address and call
+							m_HookFunc.mov(rax, reinterpret_cast<std::uint64_t>(
+								pi.pAssignOperator ? pi.pAssignOperator : pi.pCopyCtor));
+							m_HookFunc.call(rax);
+						} else {
+							// from
+							m_HookFunc.lea(rsi, rbp(OffsetToCallerStack + stack_offset));
+							// to
+							m_HookFunc.lea(rdi, rsp(stack_offset));
+							// size
+							m_HookFunc.mov(rcx, pi.size);
+							// do the copy
+							m_HookFunc.rep_movs_bytes();
+						}
+
+						stack_offset += pi.size;
+					}
+				}
 			}
 #endif
 
@@ -430,11 +589,6 @@ namespace SourceHook
 				std::int32_t v_ret_vals[] = {v_orig_ret, v_override_ret, v_plugin_ret};
 
 				for (int i = 0; i < 3; i++) {
-					// Shadow space
-					MSVC_ONLY(m_HookFunc.sub(rsp, 40));
-					// We need to keep it aligned to 16 bytes on Linux too...
-					GCC_ONLY(m_HookFunc.sub(rsp, 8));
-
 					// First param is this
 					MSVC_ONLY(m_HookFunc.lea(rcx, rbp(v_ret_vals[i])));
 					GCC_ONLY(m_HookFunc.lea(rdi, rbp(v_ret_vals[i])));
@@ -442,11 +596,6 @@ namespace SourceHook
 					// We've saved (or not) r8 value, use the freed register to store function ptr
 					m_HookFunc.mov(r8, reinterpret_cast<std::uint64_t>(retInfo.pNormalCtor));
 					m_HookFunc.call(r8);
-
-					// Free Linux stack alignment
-					GCC_ONLY(m_HookFunc.add(rsp, 8));
-					// Free shadow space
-					MSVC_ONLY(m_HookFunc.add(rsp, 40));
 				}
 			}
 
@@ -496,30 +645,24 @@ namespace SourceHook
 				stack_index++;
 			}
 
+			// TODO: Linux will need this to be using offsets into the original stack
 			for (int i = 0; i < m_Proto.GetNumOfParams(); ++i, ++stack_index) {
-				// Shadow space
-				MSVC_ONLY(m_HookFunc.sub(rsp, 40));
-				// We need to keep it aligned to 16 bytes on Linux too...
-				GCC_ONLY(m_HookFunc.sub(rsp, 8));
-				
 				const IntPassInfo &pi = m_Proto.GetParam(i);
 				if (pi.type == PassInfo::PassType_Object && (pi.flags & PassInfo::PassFlag_ODtor) &&
 					(pi.flags & PassInfo::PassFlag_ByVal)) {
-					// Every non trivial types are passed as a pointer to a special dedicated space
-					MSVC_ONLY(m_HookFunc.mov(rcx, rbp(8 + stack_index * 8)));
-					GCC_ONLY(m_HookFunc.mov(rdi, rbp(8 + stack_index * 8)));
+					// All non-trivial types are passed as a pointer to a special dedicated space
+					MSVC_ONLY(m_HookFunc.mov(rcx, rbp(OffsetToCallerStack + stack_index * 8)));
+					GCC_ONLY(m_HookFunc.mov(rdi, rbp(OffsetToCallerStack + stack_index * 8)));
 
 					m_HookFunc.mov(rax, reinterpret_cast<std::uint64_t>(pi.pDtor));
 					m_HookFunc.call(rax);
 				}
-
-				// Free Linux stack alignment
-				GCC_ONLY(m_HookFunc.add(rsp, 8));
-				// Free shadow space
-				MSVC_ONLY(m_HookFunc.add(rsp, 40));
 			}
 
 			DoReturn(v_ret_ptr, v_memret_ptr);
+			// TODO: VERY IMPORTANT! The destructor below can clobber RAX/XMM0!
+			//       It should be safe to move DoReturn() right before .leave().
+			//       FIGURE IT OUT THOUGH!!!!
 			// From then on, rax cannot be used as a general register
 			// Use r8 or r9 instead
 
@@ -528,10 +671,6 @@ namespace SourceHook
 			{
 				std::int32_t v_ret_vals[] = {v_orig_ret, v_override_ret, v_plugin_ret};
 
-				// Shadow space
-				MSVC_ONLY(m_HookFunc.sub(rsp, 40));
-				// We need to keep it aligned to 16 bytes on Linux too...
-				GCC_ONLY(m_HookFunc.sub(rsp, 8));
 				for (int i = 0; i < 3; i++) {
 					// First param is this
 					MSVC_ONLY(m_HookFunc.lea(rcx, rbp(v_ret_vals[i])));
@@ -540,16 +679,11 @@ namespace SourceHook
 					m_HookFunc.mov(r8, reinterpret_cast<std::uint64_t>(retInfo.pDtor));
 					m_HookFunc.call(r8);
 				}
-				// Free Linux stack alignment
-				GCC_ONLY(m_HookFunc.add(rsp, 8));
-				// Free shadow space
-				MSVC_ONLY(m_HookFunc.add(rsp, 40));
 			}
 
-			// Restore rbp
-			m_HookFunc.mov(rbp, rbp(v_original_rbp));
-			// Free the stack frame
-			m_HookFunc.add(rsp, stack_frame_size);
+			// Restore RSP and RBP
+			// (same as `mov rsp, rbp` + `pop rbp`)
+			m_HookFunc.leave();
 
 			m_HookFunc.retn();
 			
@@ -584,8 +718,8 @@ namespace SourceHook
 			}
 
 			// Allocate the necessary stack space
-			MSVC_ONLY(m_HookFunc.sub(rsp, 88)); // shadow space (32 bytes) + 6 stack arguments (48 bytes) + 8 bytes
-			// TODO: GCC_ONLY(m_HookFunk.sub(rsp, 8 + ?));
+			// (we already allocated enough shadow space for Windows)
+			GCC_ONLY(m_HookFunc.sub(rsp, 32));
 
 			// 1st parameter (this)
 			GCC_ONLY(m_HookFunc.mov(rdi, reinterpret_cast<std::uintptr_t>(m_SHPtr)));
@@ -615,28 +749,34 @@ namespace SourceHook
 			MSVC_ONLY(m_HookFunc.lea(rax, rbp(v_status)));
 			MSVC_ONLY(m_HookFunc.mov(rsp(0x28), rax));
 			// 7th argument - META_RES* prevResPtr
-			MSVC_ONLY(m_HookFunc.lea(rax, rbp(v_prev_res)));
+			m_HookFunc.lea(rax, rbp(v_prev_res));
 			MSVC_ONLY(m_HookFunc.mov(rsp(0x30), rax));
+			GCC_ONLY(m_HookFunc.mov(rsp(0x00), rax));
 			// 8th argument - META_RES* curResPtr
-			MSVC_ONLY(m_HookFunc.lea(rax, rbp(v_cur_res)));
+			m_HookFunc.lea(rax, rbp(v_cur_res));
 			MSVC_ONLY(m_HookFunc.mov(rsp(0x38), rax));
+			GCC_ONLY(m_HookFunc.mov(rsp(0x08), rax));
 			if (m_Proto.GetRet().size == 0) // void return function
 			{
 				// nullptr
 				m_HookFunc.xorreg(rax, rax);
 				// 9th argument - const void* origRetPtr
 				MSVC_ONLY(m_HookFunc.mov(rsp(0x40), rax));
+				GCC_ONLY(m_HookFunc.mov(rsp(0x10), rax));
 				// 10th argument - void* overrideRetPtr
 				MSVC_ONLY(m_HookFunc.mov(rsp(0x48), rax));
+				GCC_ONLY(m_HookFunc.mov(rsp(0x18), rax));
 			}
 			else
 			{
 				// 9th argument - const void* origRetPtr
-				MSVC_ONLY(m_HookFunc.lea(rax, rbp(v_orig_ret)));
+				m_HookFunc.lea(rax, rbp(v_orig_ret));
 				MSVC_ONLY(m_HookFunc.mov(rsp(0x40), rax));
+				GCC_ONLY(m_HookFunc.mov(rsp(0x10), rax));
 				// 10th argument - void* overrideRetPtr
-				MSVC_ONLY(m_HookFunc.lea(rax, rbp(v_override_ret)));
+				m_HookFunc.lea(rax, rbp(v_override_ret));
 				MSVC_ONLY(m_HookFunc.mov(rsp(0x48), rax));
+				GCC_ONLY(m_HookFunc.mov(rsp(0x18), rax));
 			}
 
 			// Retrieve the function address
@@ -646,9 +786,8 @@ namespace SourceHook
 			// Store the return value
 			m_HookFunc.mov(rbp(v_pContext), rax);
 
-			// TODO: GCC_ONLY(m_HookFunc.add(rsp, 8 + ?));
 			// Restore the rsp value
-			MSVC_ONLY(m_HookFunc.add(rsp, 88));
+			GCC_ONLY(m_HookFunc.add(rsp, 32));
 		}
 
 		// Extension of MAKE_DELEG macro
@@ -719,22 +858,12 @@ namespace SourceHook
 			m_HookFunc.mov(rax, rax()); // *this (vtable)
 			m_HookFunc.mov(rax, rax(getNext.vtblindex * SIZE_PTR)); // vtable[vtblindex]
 
-			// Shadow space 32 bytes + 8 bytes
-			MSVC_ONLY(m_HookFunc.sub(rsp, 40));
-			// We need to keep it aligned to 16 bytes on Linux too...
-			GCC_ONLY(m_HookFunc.sub(rsp, 8));
-
 			GCC_ONLY(m_HookFunc.mov(rdi, rbp(v_pContext)));
 			MSVC_ONLY(m_HookFunc.mov(rcx, rbp(v_pContext)));
 			m_HookFunc.call(rax); // pContext->GetNext()
 
 			// store into iter
 			m_HookFunc.mov(rbp(v_iter), rax);
-
-			// Free Linux stack alignment
-			GCC_ONLY(m_HookFunc.add(rsp, 8));
-			// Free shadow space
-			MSVC_ONLY(m_HookFunc.add(rsp, 40));
 
 			// null check iter
 			m_HookFunc.test(rax, rax);
@@ -779,11 +908,6 @@ namespace SourceHook
 				std::int32_t earlyLoopBack = m_HookFunc.get_outputpos() - startLoop;
 				m_HookFunc.rewrite<std::int32_t>(m_HookFunc.get_outputpos() - sizeof(std::int32_t), -earlyLoopBack);
 
-				// Shadow space 32 bytes + 8 bytes
-				MSVC_ONLY(m_HookFunc.sub(rsp, 40));
-				// We need to keep it aligned to 16 bytes on Linux too...
-				GCC_ONLY(m_HookFunc.sub(rsp, 8));
-
 				m_HookFunc.mov(rax, rbp(v_pContext));
 				m_HookFunc.mov(rax, rax()); // *this (vtable)
 				m_HookFunc.mov(rax, rax(getOverrideRetPtrMfi.vtblindex * SIZE_PTR)); // vtable[vtblindex]
@@ -791,10 +915,6 @@ namespace SourceHook
 				GCC_ONLY(m_HookFunc.mov(rdi, rbp(v_pContext)));
 				MSVC_ONLY(m_HookFunc.mov(rcx, rbp(v_pContext)));
 				m_HookFunc.call(rax); // pContext->GetOverrideRetPtr()
-
-				// Free Linux stack alignment
-				GCC_ONLY(m_HookFunc.add(rsp, 8));
-				MSVC_ONLY(m_HookFunc.add(rsp, 40));
 
 				// *reinterpret_cast<my_rettype*>(pContext->GetOverrideRetPtr()) = plugin_ret;
 
@@ -809,11 +929,6 @@ namespace SourceHook
 					// custom assignment operator, so call it
 					if (retInfo.pAssignOperator)
 					{
-						// Shadow space 32 bytes + 8 bytes
-						MSVC_ONLY(m_HookFunc.sub(rsp, 40));
-						// We need to keep it aligned to 16 bytes on Linux too...
-						GCC_ONLY(m_HookFunc.sub(rsp, 8));
-
 						// 1st parameter (this)
 						GCC_ONLY(m_HookFunc.mov(rdi, rax));
 						MSVC_ONLY(m_HookFunc.mov(rcx, rax));
@@ -825,11 +940,6 @@ namespace SourceHook
 						// Move address and call
 						m_HookFunc.mov(rax, reinterpret_cast<std::uint64_t>(retInfo.pAssignOperator));
 						m_HookFunc.call(rax);
-
-						// Free Linux stack alignment
-						GCC_ONLY(m_HookFunc.add(rsp, 8));
-						// Free shadow space
-						MSVC_ONLY(m_HookFunc.add(rsp, 40));
 					}
 					else
 					{
@@ -887,11 +997,6 @@ namespace SourceHook
 			m_HookFunc.je(0x0);
 			auto statusCmpOff = m_HookFunc.get_outputpos();
 
-			// Shadow space 32 bytes + 8 bytes
-			MSVC_ONLY(m_HookFunc.sub(rsp, 40));
-			// We need to keep it aligned to 16 bytes on Linux too...
-			GCC_ONLY(m_HookFunc.sub(rsp, 8));
-
 			m_HookFunc.mov(rax, rbp(v_pContext));
 
 			// 1st parameter (this)
@@ -902,11 +1007,6 @@ namespace SourceHook
 			m_HookFunc.mov(rax, rax(SIZE_PTR * shouldCallOrigMfi.vtblindex));
 
 			m_HookFunc.call(rax); // pContext->ShouldCallOrig()
-
-			// Free Linux stack alignment
-			GCC_ONLY(m_HookFunc.add(rsp, 8));
-			// Free shadow space
-			MSVC_ONLY(m_HookFunc.add(rsp, 40));
 
 			// Don't have the lower register yet, so this will do for now
 			m_HookFunc.test(rax, 0x1);
@@ -943,11 +1043,6 @@ namespace SourceHook
 					// custom assignment operator, so call it
 					if (retInfo.pAssignOperator)
 					{
-						// Shadow space 32 bytes + 8 bytes
-						MSVC_ONLY(m_HookFunc.sub(rsp, 40));
-						// We need to keep it aligned to 16 bytes on Linux too...
-						GCC_ONLY(m_HookFunc.sub(rsp, 8));
-
 						// 1st parameter (this)
 						GCC_ONLY(m_HookFunc.lea(rdi, rbp(v_orig_ret)));
 						MSVC_ONLY(m_HookFunc.lea(rcx, rbp(v_orig_ret)));
@@ -959,11 +1054,6 @@ namespace SourceHook
 						// Move address and call
 						m_HookFunc.mov(rax, reinterpret_cast<std::uint64_t>(retInfo.pAssignOperator));
 						m_HookFunc.call(rax);
-
-						// Free Linux stack alignment
-						GCC_ONLY(m_HookFunc.add(rsp, 8));
-						// Free shadow space
-						MSVC_ONLY(m_HookFunc.add(rsp, 40));
 					}
 					else
 					{
@@ -1021,26 +1111,21 @@ namespace SourceHook
 			}
 
 			// Allocate the shadow space
-			m_HookFunc.sub(rsp, 32);
 			stackSpace += 32;
-
 			int parameters_on_stack = m_Proto.GetNumOfParams() - parameter_index;
-			m_HookFunc.sub(rsp, parameters_on_stack * 8);
 			stackSpace += parameters_on_stack * 8;
-
-			// If this number is even we need to allocate an extra 8 bytes
-			if (parameters_on_stack % 2 == 0) {
-				m_HookFunc.sub(rsp, 8);
-				stackSpace += 8;
-			}
+			// And it needs to be 16-byte aligned...
+			m_HookFunc.sub(rsp, AlignSize(stackSpace, 16));
 
 			for (int i = 0; parameter_index < m_Proto.GetNumOfParams(); parameter_index++, i++) {
-				m_HookFunc.mov(rax, rbp(40 + (8 * i))); // We need to skip the shadow space + return address
+				m_HookFunc.mov(rax, rbp(OffsetToCallerStack + (8 * 4) + (8 * i))); // We need to skip the shadow space
 				m_HookFunc.mov(rsp(32 + (8 * i)), rax);
 			}
 
 			return stackSpace;
 #else
+			// TODO: Fix up this shit for objects passed inline on the stack
+
 			const x86_64_Reg params_reg[] = { rdi, rsi, rdx, rcx, r8, r9 };
 			const x86_64_FloatReg params_floatreg[] = { xmm0, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7 };
 			const std::uint8_t num_reg = sizeof(params_reg) / sizeof(params_reg[0]);
@@ -1049,15 +1134,16 @@ namespace SourceHook
 			int reg_index = 0;
 			int floatreg_index = 0;
 
-			// setup this parameter
-			m_HookFunc.mov(params_reg[reg_index], rbp(v_this));
-			reg_index++;
-
+			// TODO: What am I doing here?
 			// Non standard return
 			if (retInfo.size != 0 && (retInfo.flags & PassInfo::PassFlag_RetMem) == PassInfo::PassFlag_RetMem) {
 				m_HookFunc.lea(params_reg[reg_index], rbp(v_ret));
 				reg_index++;
 			}
+
+			// setup this parameter
+			m_HookFunc.mov(params_reg[reg_index], rbp(v_this));
+			reg_index++;
 
 			// TODO: Doesn't handle custom_register at all........
 
@@ -1083,15 +1169,16 @@ namespace SourceHook
 			// Actually push registers to stack...
 			for (int i = 0, pushed_stack_parameters = 0; i < m_Proto.GetNumOfParams(); i++) {
 				auto& info = m_Proto.GetParam(i);
+				// TODO: These offsets are WRONG
 				if (info.type == PassInfo::PassType_Float && (info.flags & PassInfo::PassFlag_ByRef) != PassInfo::PassFlag_ByRef) {
 					if (++floatreg_index >= num_floatreg) {
-						m_HookFunc.mov(rax, rbp(8 + (8 * pushed_stack_parameters)));
+						m_HookFunc.mov(rax, rbp(OffsetToCallerStack + (8 * pushed_stack_parameters)));
 						m_HookFunc.mov(rsp(0 + (8 * pushed_stack_parameters)), rax);
 						pushed_stack_parameters++;
 					}
 				} else {
 					if (++reg_index >= num_reg) {
-						m_HookFunc.mov(rax, rbp(8 + (8 * pushed_stack_parameters)));
+						m_HookFunc.mov(rax, rbp(OffsetToCallerStack + (8 * pushed_stack_parameters)));
 						m_HookFunc.mov(rsp(0 + (8 * pushed_stack_parameters)), rax);
 						pushed_stack_parameters++;
 					}
@@ -1114,8 +1201,9 @@ namespace SourceHook
 				return;
 			}
 
-			// ByVal
+			// TOOD: handle Vector3f into XMM0 & XMM1 for Linux64 here....
 
+			// ByVal
 			if (retInfo.type == PassInfo::PassType_Float) {
 				m_HookFunc.movsd(rbp(v_ret), xmm0);
 			} else if (retInfo.type == PassInfo::PassType_Basic) {
@@ -1123,11 +1211,6 @@ namespace SourceHook
 			} else if ((retInfo.flags & PassInfo::PassFlag_RetMem) == PassInfo::PassFlag_RetMem) {
 				if (MemRetWithTempObj()) {
 					if (retInfo.pAssignOperator) {
-						// Shadow space 32 bytes + 8 bytes
-						MSVC_ONLY(m_HookFunc.sub(rsp, 40));
-						// We need to keep it aligned to 16 bytes on Linux too...
-						GCC_ONLY(m_HookFunc.sub(rsp, 8));
-
 						// 1st parameter (this)
 						GCC_ONLY(m_HookFunc.lea(rdi, rbp(v_ret)));
 						MSVC_ONLY(m_HookFunc.lea(rcx, rbp(v_ret)));
@@ -1139,11 +1222,6 @@ namespace SourceHook
 						// Move address and call
 						m_HookFunc.mov(rax, reinterpret_cast<std::uint64_t>(retInfo.pAssignOperator));
 						m_HookFunc.call(rax);
-
-						// Free Linux stack alignment
-						GCC_ONLY(m_HookFunc.add(rsp, 8));
-						// Free shadow space
-						MSVC_ONLY(m_HookFunc.add(rsp, 40));
 					}
 					else {
 						m_HookFunc.push(rdi);
@@ -1162,11 +1240,6 @@ namespace SourceHook
 					}
 
 					if (retInfo.pDtor) {
-						// Shadow space 32 bytes + 8 bytes
-						MSVC_ONLY(m_HookFunc.sub(rsp, 40));
-						// We need to keep it aligned to 16 bytes on Linux too...
-						GCC_ONLY(m_HookFunc.sub(rsp, 8));
-
 						// 1st parameter (this)
 						GCC_ONLY(m_HookFunc.lea(rdi, rbp(v_mem_ret)));
 						MSVC_ONLY(m_HookFunc.lea(rcx, rbp(v_mem_ret)));
@@ -1174,11 +1247,6 @@ namespace SourceHook
 						// Move address and call
 						m_HookFunc.mov(rax, reinterpret_cast<std::uint64_t>(retInfo.pDtor));
 						m_HookFunc.call(rax);
-
-						// Free Linux stack alignment
-						GCC_ONLY(m_HookFunc.add(rsp, 8));
-						// Free shadow space
-						MSVC_ONLY(m_HookFunc.add(rsp, 40));
 					}
 
 				} else {
@@ -1228,27 +1296,16 @@ namespace SourceHook
 			m_HookFunc.mov(rax, rax(getOrigRetPtrMfi.vtblindex * SIZE_PTR));
 			m_HookFunc.mov(r8, r8(getOverrideRetPtrMfi.vtblindex * SIZE_PTR));
 
-			m_HookFunc.xorreg(r9, r9);
 			m_HookFunc.mov(r9, rbp(v_status));
 			m_HookFunc.cmp(r9, MRES_OVERRIDE);
 
 			m_HookFunc.cmovge(rax, r8);
-
-			// Shadow space 32 bytes + 8 bytes
-			MSVC_ONLY(m_HookFunc.sub(rsp, 40));
-			// We need to keep it aligned to 16 bytes on Linux too...
-			GCC_ONLY(m_HookFunc.sub(rsp, 8));
 
 			// 1st parameter (this)
 			GCC_ONLY(m_HookFunc.mov(rdi, rbp(v_pContext)));
 			MSVC_ONLY(m_HookFunc.mov(rcx, rbp(v_pContext)));
 
 			m_HookFunc.call(rax);
-
-			// Free Linux stack alignment
-			GCC_ONLY(m_HookFunc.add(rsp, 8));
-			// Free shadow space
-			MSVC_ONLY(m_HookFunc.add(rsp, 40));
 
 			m_HookFunc.mov(rbp(v_retptr), rax);
 		}
@@ -1261,6 +1318,8 @@ namespace SourceHook
 			}
 
 			m_HookFunc.mov(r8, rbp(v_retptr));
+
+			// TOOD: handle Vector3f into XMM0 & XMM1 for Linux64 here....
 
 			if (retInfo.flags & PassInfo::PassFlag_ByRef) {
 				m_HookFunc.mov(rax, r8());
@@ -1281,11 +1340,6 @@ namespace SourceHook
 				// *memret_outaddr = plugin_ret
 				if (retInfo.pCopyCtor)
 				{
-					// Shadow space 32 bytes + 8 bytes
-					MSVC_ONLY(m_HookFunc.sub(rsp, 40));
-					// We need to keep it aligned to 16 bytes on Linux too...
-					GCC_ONLY(m_HookFunc.sub(rsp, 8));
-
 					// 1st parameter (this)
 					GCC_ONLY(m_HookFunc.mov(rdi, rbp(v_memret_outaddr)));
 					MSVC_ONLY(m_HookFunc.mov(rcx, rbp(v_memret_outaddr)));
@@ -1297,11 +1351,6 @@ namespace SourceHook
 					// Move address and call
 					m_HookFunc.mov(rax, reinterpret_cast<std::uint64_t>(retInfo.pCopyCtor));
 					m_HookFunc.call(rax);
-
-					// Free Linux stack alignment
-					GCC_ONLY(m_HookFunc.add(rsp, 8));
-					// Free shadow space
-					MSVC_ONLY(m_HookFunc.add(rsp, 40));
 				}
 				else
 				{
@@ -1337,11 +1386,6 @@ namespace SourceHook
 				}
 			}
 
-			// Shadow space 32 bytes + 8 bytes
-			MSVC_ONLY(m_HookFunc.sub(rsp, 40));
-			// We need to keep it aligned to 16 bytes on Linux too...
-			GCC_ONLY(m_HookFunc.sub(rsp, 8));
-
 			// 1st parameter (this)
 			GCC_ONLY(m_HookFunc.mov(rdi, reinterpret_cast<std::uintptr_t>(m_SHPtr)));
 			MSVC_ONLY(m_HookFunc.mov(rcx, reinterpret_cast<std::uintptr_t>(m_SHPtr)));
@@ -1353,11 +1397,6 @@ namespace SourceHook
 			// Move address and call
 			m_HookFunc.mov(rax, (*reinterpret_cast<std::uintptr_t**>(m_SHPtr))[mfi.vtblindex]);
 			m_HookFunc.call(rax);
-
-			// Free Linux stack alignment
-			GCC_ONLY(m_HookFunc.add(rsp, 8));
-			// Free shadow space
-			MSVC_ONLY(m_HookFunc.add(rsp, 40));
 		}
 
 		bool x64GenContext::MemRetWithTempObj() {
@@ -1401,13 +1440,13 @@ namespace SourceHook
 					// If the user says nothing, auto-detect
 					if ((pi.flags & (PassInfo::PassFlag_RetMem | PassInfo::PassFlag_RetReg)) == 0)
 					{
-						bool hasSpecialFunctions = (pi.flags & (PassInfo::PassFlag_OCtor|PassInfo::PassFlag_ODtor|PassInfo::PassFlag_CCtor)) != 0;
 
 #if SH_COMP == SH_COMP_MSVC
 						// MSVC has various criteria for passing in memory
 						// if object doesn't fit on 8, 16, 32, or 64 bits. It's in memory
 						// if object has a constructor or destructor. It's in memory
 						bool unconventionalsize = (pi.size == 3 || (pi.size != 8 && pi.size > 4));
+						bool hasSpecialFunctions = (pi.flags & (PassInfo::PassFlag_OCtor|PassInfo::PassFlag_ODtor|PassInfo::PassFlag_CCtor)) != 0;
 
 						if (unconventionalsize || hasSpecialFunctions) {
 							pi.flags |= PassInfo::PassFlag_RetMem;
@@ -1445,8 +1484,11 @@ namespace SourceHook
 						// Result: we cannot detect if it should be register or memory without knowing the layout of the object.
 
 						bool tooBig = (pi.size > (8 * 8));
+						bool hasSpecialFunctions = (pi.flags & (PassInfo::PassFlag_ODtor|PassInfo::PassFlag_CCtor)) != 0;
 
-						if (hasSpecialFunctions || tooBig)
+						bool probablyVector = (pi.size == 12);
+
+						if (hasSpecialFunctions || tooBig || probablyVector)
 						{
 							pi.flags |= PassInfo::PassFlag_RetMem;
 							return true;
@@ -1468,7 +1510,7 @@ namespace SourceHook
 			return true;
 		}
 
-		void x64GenContext::AutoDetectParamFlags()
+		bool x64GenContext::AutoDetectParamFlags()
 		{
 		}
 
@@ -1486,15 +1528,14 @@ namespace SourceHook
 			//    if (hi)
 			//      hi->SetInfo(HOOKMAN_VERSION, m_VtblOffs, m_VtblIdx, m_Proto.GetProto(), m_HookfuncVfnptr)
 			//  }
+			
+			// Save our frame pointer. (somewhat needlessly on Windows...)
+			// This also realigns the stack to 16 bytes.
+			m_PubFunc.push(rbp);
+			m_PubFunc.mov(rbp, rsp);
 
 			// prologue
-			MSVC_ONLY(m_PubFunc.sub(rsp, 0x38)); // Shadow space 32 bytes + 2 * 8 bytes (for our parameters) + 8 bytes
-			// TODO: GCC_ONLY(m_PubFunc.sub(rsp, 8+?));
-			
-			// Frame pointer! We like working callstacks when debugging crashes!
-			// TODO: Might mean we don't have to `sub rsp, 8`?
-			GCC_ONLY(m_PubFunc.push(rbp));
-			GCC_ONLY(m_PubFunc.mov(rbp, rsp));
+			MSVC_ONLY(m_PubFunc.sub(rsp, 0x30)); // Shadow space 32 bytes + 2 * 8 bytes (for our parameters)
 
 			// Both Microsoft and AMD uses r8 and r9 as argument parameters
 			// Therefore they need not to be preserved across function calls
@@ -1569,13 +1610,9 @@ namespace SourceHook
 			m_PubFunc.rewrite<std::int32_t>(jumpOff - sizeof(std::int32_t), endOff);
 
 			// epilogue
-
-			// Free Linux stack alignment
-			// TODO: GCC_ONLY(m_HookFunc.add(rsp, 8 + ?));
-			// Free shadow space & parameter space & stack alignment
-			MSVC_ONLY(m_PubFunc.add(rsp, 0x38));
-
-			GCC_ONLY(m_PubFunc.pop(rbp));
+			// Restore RSP and RBP
+			// (same as `mov rsp, rbp` + `pop rbp`)
+			m_PubFunc.leave();
 
 			// Return 0
 			m_PubFunc.xorreg(rax, rax);

--- a/core/sourcehook/sourcehook_hookmangen_x86_64.cpp
+++ b/core/sourcehook/sourcehook_hookmangen_x86_64.cpp
@@ -16,13 +16,18 @@
 // https://refspecs.linuxbase.orgz/elf/x86_64-abi-0.99.pdf
 // SystemV AMD64 https://gitlab.com/x86-psABIs/x86-64-ABI/-/jobs/artifacts/master/raw/x86-64-ABI/abi.pdf?job=build
 
-#include <stdio.h>
+#include <cstdio>
+#include <cstdarg>							// we might need the address of vsnprintf
 #include <string>
 #include "sourcehook_impl.h"
 #include "sourcehook_hookmangen.h"
 #include "sourcehook_hookmangen_x86_64.h"
 #include "sourcehook_pibuilder.h"
 
+// PrintDebug below writes through metamod's provider, which the standalone
+// SourceHook test does not link against - and having it here is what kept that
+// test from being built for 64 bit Linux at all.
+#if !defined(SOURCEHOOK_TESTS)
 #include "metamod_oslink.h"
 #include "metamod.h"
 #include <interface.h>
@@ -32,6 +37,7 @@
 
 extern SourceHook::ISourceHook *g_SHPtr;
 extern SourceMM::IMetamodSourceProvider *provider;
+#endif
 
 #if SH_COMP == SH_COMP_MSVC
 # define GCC_ONLY(x)
@@ -51,6 +57,7 @@ namespace SourceHook
 {
 	namespace Impl
 	{
+#if !defined(SOURCEHOOK_TESTS)
 		void PrintDebug(x64JitWriter& jit, const char* message) {
 			static MemFuncInfo mfi = {false, -1, -1, -1};
 			if (mfi.vtblindex == -1)
@@ -100,16 +107,7 @@ namespace SourceHook
 			jit.call(rax);
 		}
 
-		x64GenContext::x64GenContext()
-			: m_GeneratedPubFunc(nullptr), m_VtblOffs(0),
-			  m_VtblIdx(666), m_SHPtr((ISourceHook*)0x1122334455667788), m_pHI(nullptr), m_HookfuncVfnptr(nullptr), m_HookFunc_FrameOffset(0), m_HookFunc_FrameVarsSize(0) {
-			m_pHI = new void*;
-			*m_pHI = (void*)0x77777777;
-			m_HookfuncVfnptr = new void*;
-			m_BuiltPI = new ProtoInfo;
-			m_BuiltPI_Params = nullptr;
-			m_BuiltPI_Params2 = nullptr;
-		}
+#endif
 
 		x64GenContext::x64GenContext(const ProtoInfo *proto, int vtbl_offs, int vtbl_idx, ISourceHook *pSHPtr)
 			: m_GeneratedPubFunc(nullptr), m_OrigProto(proto), m_Proto(proto), m_VtblOffs(vtbl_offs),
@@ -267,6 +265,31 @@ namespace SourceHook
 				}
 			}
 
+#if SH_COMP == SH_COMP_GCC
+			// Both mechanisms below reach for a specific argument register, so a proto
+			// that pushes one of them onto the stack is declined rather than generated
+			// wrong.  It takes six integer args before that happens.
+			const int num_int_reg = 6;
+			for (int i = 0; i < m_Proto.GetNumOfParams(); ++i)
+			{
+				if ((m_Proto.GetParam(i).flags & PassFlag_ForcedByRef) &&
+					GetIntRegForParam(i) >= num_int_reg)
+				{
+					return nullptr;
+				}
+			}
+			if (m_Proto.GetConvention() & ProtoInfo::CallConv_HasVafmt)
+			{
+				// The original is called with two arguments in place of the format
+				// string and its varargs, so both slots have to be registers.
+				if (GetIntRegForParam(m_Proto.GetNumOfParams()) + 1 >= num_int_reg ||
+					GetNumFloatParams() > 8)
+				{
+					return nullptr;
+				}
+			}
+#endif
+
 			BuildProtoInfo();
 			GenerateHookFunc();
 			return fastdelegate::detail::horrible_cast<HookManagerPubFunc>(GeneratePubFunc());
@@ -308,7 +331,6 @@ namespace SourceHook
 		void* x64GenContext::GenerateHookFunc()
 		{
 			const auto& retInfo = m_Proto.GetRet();
-			m_HookFunc.breakpoint();
 
 			// For the time being, we only consider xmm0-xmm15 registers
 			// are only used to store 64bits worth of data, despite being
@@ -460,6 +482,25 @@ namespace SourceHook
 			v_sysv_floatreg = AddVarToFrame(num_floatreg * 8);
 			v_sysv_reg = AddVarToFrame(num_reg * 8);
 
+			// Room for one private copy of every forced-by-ref param.  Reused by each
+			// call the hook func makes, since a copy never outlives the call it is
+			// made for.
+			v_fbrr_base = 0;
+			if (GetForcedByRefParamsSize())
+				v_fbrr_base = AddVarToFrame(AlignSize(GetForcedByRefParamsSize(), 16));
+
+			// vafmt: the formatted string, plus the register save area and the cursor
+			// over it that a va_list is on this ABI.
+			v_va_buf = 0;
+			v_va_regsave = 0;
+			v_va_list = 0;
+			if (m_Proto.GetConvention() & ProtoInfo::CallConv_HasVafmt)
+			{
+				v_va_buf = AddVarToFrame(AlignSize(SourceHook::STRBUF_LEN, 16));
+				v_va_regsave = AddVarToFrame(6 * 8 + 8 * 16);
+				v_va_list = AddVarToFrame(32);
+			}
+
 			std::int32_t stack_frame_size = AlignSize(ComputeVarsSize(), 16);
 			m_HookFunc.sub(rsp, stack_frame_size);
 
@@ -468,6 +509,45 @@ namespace SourceHook
 			}
 			for (int i = 0; i < num_floatreg; i++) {
 				m_HookFunc.movsd(rbp(v_sysv_floatreg + i*8), params_floatreg[i]);
+			}
+
+			// vafmt: hooks are handed one already formatted string in place of the
+			// format and its varargs, so the formatting happens here, once, before any
+			// of them run.  Walking the varargs needs a va_list, which on this ABI is a
+			// cursor over a register save area laid out exactly as the ABI describes -
+			// integer registers first, then the SSE ones on a 16 byte stride - followed
+			// by whatever the caller put on the stack.
+			if (m_Proto.GetConvention() & ProtoInfo::CallConv_HasVafmt)
+			{
+				for (int i = 0; i < num_reg; i++) {
+					m_HookFunc.mov(rbp(v_va_regsave + i * 8), params_reg[i]);
+				}
+				for (int i = 0; i < num_floatreg; i++) {
+					m_HookFunc.movsd(rbp(v_va_regsave + 6 * 8 + i * 16), params_floatreg[i]);
+				}
+
+				// gp_offset and fp_offset: how far into each save area the declared
+				// args, the format string included, have already got.
+				int fmt_reg = GetIntRegForParam(m_Proto.GetNumOfParams());
+				std::uint64_t gp_offset = static_cast<std::uint64_t>((fmt_reg + 1) * 8);
+				std::uint64_t fp_offset = static_cast<std::uint64_t>(6 * 8 + GetNumFloatParams() * 16);
+				m_HookFunc.mov(rax, (fp_offset << 32) | gp_offset);
+				m_HookFunc.mov(rbp(v_va_list), rax);
+
+				m_HookFunc.lea(rax, rbp(OffsetToCallerStack + GetNamedArgsStackSize()));
+				m_HookFunc.mov(rbp(v_va_list + 8), rax);
+				m_HookFunc.lea(rax, rbp(v_va_regsave));
+				m_HookFunc.mov(rbp(v_va_list + 16), rax);
+
+				// vsnprintf(va_buf, STRBUF_LEN, fmt, va_list) - it terminates within
+				// the size it is given, so there is nothing to fix up afterwards.
+				m_HookFunc.lea(rdi, rbp(v_va_buf));
+				m_HookFunc.mov(rsi, static_cast<std::int32_t>(SourceHook::STRBUF_LEN));
+				m_HookFunc.mov(rdx, rbp(v_sysv_reg + fmt_reg * 8));
+				m_HookFunc.lea(rcx, rbp(v_va_list));
+				m_HookFunc.mov(rax, reinterpret_cast<std::uint64_t>(
+					static_cast<int (*)(char *, size_t, const char *, va_list)>(&vsnprintf)));
+				m_HookFunc.call(rax);
 			}
 #endif
 
@@ -528,26 +608,33 @@ namespace SourceHook
 
 			CallEndContext(v_pContext);
 
-			// Call destructors of byval object params which have a destructor
+#if SH_COMP == SH_COMP_MSVC
+			// Call destructors of byval object params which have a destructor.
+			// MSVC only: under the Itanium ABI the caller destroys the arguments it
+			// passed, and the copies this function made are destroyed after the call
+			// they were made for (see DestroyParams).
 			int stack_index = 1; // account this pointer
 			if ((retInfo.flags & PassInfo::PassFlag_RetMem) == PassInfo::PassFlag_RetMem) {
 				// Non trivial return value
 				stack_index++;
 			}
 
-			// TODO: Linux64...
 			for (int i = 0; i < m_Proto.GetNumOfParams(); ++i, ++stack_index) {
 				const IntPassInfo &pi = m_Proto.GetParam(i);
 				if (pi.type == PassInfo::PassType_Object && (pi.flags & PassInfo::PassFlag_ODtor) &&
 					(pi.flags & PassInfo::PassFlag_ByVal)) {
 					// All non-trivial types are passed as a pointer to a special dedicated space
-					MSVC_ONLY(m_HookFunc.mov(rcx, rbp(OffsetToCallerStack + stack_index * 8)));
-					GCC_ONLY(m_HookFunc.mov(rdi, rbp(OffsetToCallerStack + stack_index * 8)));
+					m_HookFunc.mov(rcx, rbp(OffsetToCallerStack + stack_index * 8));
 
 					m_HookFunc.mov(rax, reinterpret_cast<std::uint64_t>(pi.pDtor));
 					m_HookFunc.call(rax);
 				}
 			}
+#endif
+
+			// Hand the return value back before the three objects below are destroyed:
+			// the one being returned is one of them.
+			DoReturn(v_ret_ptr, v_memret_ptr);
 
 			// If return value type has a destructor, call it
 			if ((retInfo.flags & PassInfo::PassFlag_ByVal) && retInfo.pDtor != nullptr)
@@ -562,9 +649,12 @@ namespace SourceHook
 					m_HookFunc.mov(r8, reinterpret_cast<std::uint64_t>(retInfo.pDtor));
 					m_HookFunc.call(r8);
 				}
-			}
 
-			DoReturn(v_ret_ptr, v_memret_ptr);
+				// Those calls clobbered what DoReturn left in rax.
+				if ((retInfo.flags & PassInfo::PassFlag_RetMem) == PassInfo::PassFlag_RetMem) {
+					m_HookFunc.mov(rax, rbp(v_memret_ptr));
+				}
+			}
 			// From then on, rax cannot be used as a general register
 			// Use r8 or r9 instead
 
@@ -764,7 +854,7 @@ namespace SourceHook
 			m_HookFunc.mov(rbp(v_prev_res), rax);
 
 			// call
-			std::int32_t stackSpace = PushParameters(v_iter, MemRetWithTempObj() ? v_mem_ret : v_plugin_ret);
+			std::int32_t stackSpace = PushParameters(v_iter, MemRetWithTempObj() ? v_mem_ret : v_plugin_ret, false);
 			m_HookFunc.mov(rax, rbp(v_iter));
 			m_HookFunc.mov(rax, rax()); // *this (vtable)
 			m_HookFunc.mov(rax, rax(callMfi.vtblindex * SIZE_PTR)); // vtable[vtblindex] iter -> Call
@@ -776,6 +866,8 @@ namespace SourceHook
 			}
 
 			SaveReturnValue(v_mem_ret, v_plugin_ret);
+
+			DestroyParams();
 
 			// if (cur_res > status)
 			m_HookFunc.mov(rax, rbp(v_cur_res));
@@ -903,9 +995,24 @@ namespace SourceHook
 			auto shouldCallOff = m_HookFunc.get_outputpos();
 
 			// original call
-			std::int32_t stackSpace = PushParameters(v_this, MemRetWithTempObj() ? v_place_for_memret : v_orig_ret);
-			m_HookFunc.mov(rax, rbp(v_vfnptr_origentry));
-			m_HookFunc.call(rax);
+			std::int32_t stackSpace = PushParameters(v_this, MemRetWithTempObj() ? v_place_for_memret : v_orig_ret, true);
+#if SH_COMP == SH_COMP_GCC
+			if (m_Proto.GetConvention() & ProtoInfo::CallConv_HasVafmt)
+			{
+				// A vafmt original is variadic, and the ABI passes the number of vector
+				// registers used for the variable part in al.  None are: what replaces
+				// the varargs is "%s" and a pointer.  Somewhere other than rax has to
+				// hold the target for al to survive to the call.
+				m_HookFunc.mov(r11, rbp(v_vfnptr_origentry));
+				m_HookFunc.mov(rax, static_cast<std::int32_t>(0));
+				m_HookFunc.call(r11);
+			}
+			else
+#endif
+			{
+				m_HookFunc.mov(rax, rbp(v_vfnptr_origentry));
+				m_HookFunc.call(rax);
+			}
 			if (stackSpace)
 			{
 				// epilog free the stack
@@ -913,6 +1020,8 @@ namespace SourceHook
 			}
 
 			SaveReturnValue(v_place_for_memret, v_orig_ret);
+
+			DestroyParams();
 
 			m_HookFunc.jump(0x0);
 			auto callOriginalOff = m_HookFunc.get_outputpos();
@@ -969,7 +1078,7 @@ namespace SourceHook
 			m_HookFunc.rewrite(callOriginalOff - sizeof(std::int32_t), static_cast<std::int32_t>(m_HookFunc.get_outputpos() - callOriginalOff));
 		}
 
-		std::int32_t x64GenContext::PushParameters(int v_this, int v_ret)
+		std::int32_t x64GenContext::PushParameters(int v_this, int v_ret, bool orig_call)
 		{
 			auto retInfo = m_Proto.GetRet();
 			std::int32_t stackSpace = 0;
@@ -1065,7 +1174,8 @@ namespace SourceHook
 						stackSpace += 8;
 					}
 				} else if (info.type == PassInfo::PassType_Object) {
-					if (info.flags & PassInfo::PassFlag_ByRef) {
+					if (info.flags & (PassInfo::PassFlag_ByRef | PassFlag_ForcedByRef)) {
+						// Both arrive, and are passed on, as a pointer.
 						if (++reg_index >= num_reg) {
 							stackSpace += 8;
 						}
@@ -1079,7 +1189,9 @@ namespace SourceHook
 			{
 				stackSpace = AlignSize(stackSpace, 16);
 				m_HookFunc.sub(rsp, stackSpace);
-	
+			}
+
+			{
 				// Actually push registers to stack...
 				reg_index = orig_reg_index;
 				floatreg_index = 0;
@@ -1102,7 +1214,38 @@ namespace SourceHook
 							stack_offset += 8;
 						}
 					} else if (info.type == PassInfo::PassType_Object) {
-						if (info.flags & PassInfo::PassFlag_ByRef) {
+						if (info.flags & PassFlag_ForcedByRef) {
+							// What arrived is a pointer to the caller's object. Copy it
+							// into our own block so the callee cannot reach back into
+							// the caller's, then pass the copy instead.
+							int src_reg = GetIntRegForParam(i);
+							bool src_on_stack = (src_reg >= num_reg);
+							++reg_index;
+
+							m_HookFunc.lea(rdi, rbp(v_fbrr_base + GetForcedByRefParamOffset(i)));
+							if (src_on_stack) {
+								m_HookFunc.mov(rsi, rbp(OffsetToCallerStack + stack_offset));
+							} else {
+								m_HookFunc.mov(rsi, rbp(v_sysv_reg + src_reg * 8));
+							}
+
+							if (info.pCopyCtor) {
+								// copy->CopyCtor(original)
+								m_HookFunc.mov(rax, reinterpret_cast<std::uint64_t>(info.pCopyCtor));
+								m_HookFunc.call(rax);
+							} else {
+								m_HookFunc.mov(rcx, info.size);
+								m_HookFunc.rep_movs_bytes();
+							}
+
+							if (src_on_stack) {
+								// The callee reads it off the stack, so the slot has to
+								// hold the copy's address, not the original's.
+								m_HookFunc.lea(rax, rbp(v_fbrr_base + GetForcedByRefParamOffset(i)));
+								m_HookFunc.mov(rsp(stack_offset), rax);
+								stack_offset += 8;
+							}
+						} else if (info.flags & PassInfo::PassFlag_ByRef) {
 							if (++reg_index >= num_reg) {
 								m_HookFunc.lea(rax, rbp(OffsetToCallerStack + stack_offset));
 								m_HookFunc.mov(rax, rax());
@@ -1146,6 +1289,8 @@ namespace SourceHook
 				reg_index++;
 			}
 
+			int this_reg_index = reg_index;
+
 			for (int i = reg_index; i < num_reg; i++) {
 				m_HookFunc.mov(params_reg[i], rbp(v_sysv_reg + i*8));
 			}
@@ -1153,7 +1298,62 @@ namespace SourceHook
 				m_HookFunc.movsd(params_floatreg[i], rbp(v_sysv_floatreg + i*8));
 			}
 
+			// The backup holds the this pointer the hooked function was called with.
+			// That is the right one for the original call, but a hook call has to go to
+			// the delegate, so this always comes from v_this and never from the backup.
+			m_HookFunc.mov(params_reg[this_reg_index], rbp(v_this));
+
+			// Same for a forced-by-ref param: the backup holds the caller's object, and
+			// what goes out is the copy made above.
+			for (int i = 0; i < m_Proto.GetNumOfParams(); i++) {
+				const auto& info = m_Proto.GetParam(i);
+				if ((info.flags & PassFlag_ForcedByRef) == 0)
+					continue;
+
+				int param_reg = GetIntRegForParam(i);
+				if (param_reg < num_reg) {
+					m_HookFunc.lea(params_reg[param_reg], rbp(v_fbrr_base + GetForcedByRefParamOffset(i)));
+				}
+			}
+
+			// vafmt: hooks take the formatted string where the declared params end.
+			// The original is variadic and gets "%s" and that same string, so that it
+			// formats to what the hooks were shown rather than a second time.
+			if (m_Proto.GetConvention() & ProtoInfo::CallConv_HasVafmt)
+			{
+				int fmt_reg = GetIntRegForParam(m_Proto.GetNumOfParams());
+				if (orig_call)
+				{
+					static const char vafmt_passthrough[] = "%s";
+					m_HookFunc.mov(params_reg[fmt_reg], reinterpret_cast<std::uint64_t>(vafmt_passthrough));
+					m_HookFunc.lea(params_reg[fmt_reg + 1], rbp(v_va_buf));
+				}
+				else
+				{
+					m_HookFunc.lea(params_reg[fmt_reg], rbp(v_va_buf));
+				}
+			}
+
 			return stackSpace;
+#endif
+		}
+
+		// Destroys the private copies PushParameters made for the call that has just
+		// returned.  Kept separate from the return value handling: it clobbers rax, so
+		// it has to run after SaveReturnValue.
+		void x64GenContext::DestroyParams()
+		{
+#if SH_COMP == SH_COMP_GCC
+			for (int i = 0; i < m_Proto.GetNumOfParams(); ++i)
+			{
+				const IntPassInfo &pi = m_Proto.GetParam(i);
+				if ((pi.flags & PassFlag_ForcedByRef) == 0 || !pi.pDtor)
+					continue;
+
+				m_HookFunc.lea(rdi, rbp(v_fbrr_base + GetForcedByRefParamOffset(i)));
+				m_HookFunc.mov(rax, reinterpret_cast<std::uint64_t>(pi.pDtor));
+				m_HookFunc.call(rax);
+			}
 #endif
 		}
 
@@ -1185,6 +1385,13 @@ namespace SourceHook
 				m_HookFunc.movsd(rbp(v_ret), xmm0);
 			} else if (retInfo.type == PassInfo::PassType_Basic) {
 				m_HookFunc.mov(rbp(v_ret), rax);
+			} else if ((retInfo.flags & PassInfo::PassFlag_RetReg) == PassInfo::PassFlag_RetReg) {
+				// At most two eightbytes, INTEGER class (the SSE case is the size == 12
+				// one handled above).
+				m_HookFunc.mov(rbp(v_ret), rax);
+				if (retInfo.size > 8) {
+					m_HookFunc.mov(rbp(v_ret + 8), rdx);
+				}
 			} else if ((retInfo.flags & PassInfo::PassFlag_RetMem) == PassInfo::PassFlag_RetMem) {
 				if (MemRetWithTempObj()) {
 					if (retInfo.pAssignOperator) {
@@ -1319,6 +1526,9 @@ namespace SourceHook
 			else if (retInfo.type == PassInfo::PassType_Basic || 
 				((retInfo.type == PassInfo::PassType_Object) && (retInfo.flags & PassInfo::PassFlag_RetReg)) ) {
 				m_HookFunc.mov(rax, r8());
+				if (retInfo.type == PassInfo::PassType_Object && retInfo.size > 8) {
+					m_HookFunc.mov(rdx, r8(8));
+				}
 			}
 
 			if (retInfo.flags & PassInfo::PassFlag_RetMem)
@@ -1456,25 +1666,25 @@ namespace SourceHook
 						//
 						// Result: we cannot detect if it should be register or memory without knowing the layout of the object.
 
-						bool tooBig = (pi.size > (8 * 8));
+						// Anything above two eightbytes is MEMORY, and so is anything
+						// non-trivial for the purpose of calls.
+						bool tooBig = (pi.size > 16);
 						bool hasSpecialFunctions = (pi.flags & (PassInfo::PassFlag_ODtor|PassInfo::PassFlag_CCtor)) != 0;
-
-						bool probablyVector = (pi.size == 12);
 
 						if (hasSpecialFunctions || tooBig)
 						{
 							pi.flags |= PassInfo::PassFlag_RetMem;
-							return true;
-						}
-						else if (probablyVector)
-						{
-							pi.flags |= PassInfo::PassFlag_RetReg;
-							return true;
 						}
 						else
 						{
-							return false;
+							// Register return. Which registers depends on whether each
+							// eightbyte is SSE or INTEGER, and a PassInfo carries sizes
+							// but not field types, so it cannot be derived here. The
+							// integer registers are assumed, with the exception below
+							// for the one float aggregate the SDK returns everywhere.
+							pi.flags |= PassInfo::PassFlag_RetReg;
 						}
+						return true;
 #endif
 					}
 				}
@@ -1490,6 +1700,142 @@ namespace SourceHook
 
 		void x64GenContext::AutoDetectParamFlags()
 		{
+#if SH_COMP == SH_COMP_GCC
+			// "If a C++ object is non-trivial for the purpose of calls [...] it is passed
+			// by invisible reference": what arrives is a pointer to the caller's object,
+			// not a copy of it.  The hook func has to copy it itself, once per call, or
+			// every hook and the original would be handed the same object.
+			for (int i = 0; i < m_Proto.GetNumOfParams(); ++i)
+			{
+				IntPassInfo &pi = m_Proto.GetParam(i);
+				if (pi.type == PassInfo::PassType_Object &&
+					(pi.flags & PassInfo::PassFlag_ByVal) &&
+					(pi.flags & (PassInfo::PassFlag_ODtor | PassInfo::PassFlag_CCtor)))
+				{
+					pi.flags |= PassFlag_ForcedByRef;
+				}
+			}
+#endif
+		}
+
+		// Offset of param p's private copy, relative to the base of the block, and the
+		// size of the whole block when passed the param count.
+		std::int32_t x64GenContext::GetForcedByRefParamOffset(int p)
+		{
+			std::int32_t offset = 0;
+			for (int i = 0; i < p; ++i)
+			{
+				const IntPassInfo &pi = m_Proto.GetParam(i);
+				if (pi.flags & PassFlag_ForcedByRef)
+					offset += AlignSize(static_cast<std::int32_t>(pi.size), SIZE_PTR);
+			}
+			return offset;
+		}
+
+		std::int32_t x64GenContext::GetForcedByRefParamsSize()
+		{
+			return GetForcedByRefParamOffset(m_Proto.GetNumOfParams());
+		}
+
+		// The integer register the first declared param arrives in: after the hidden
+		// return pointer, if there is one, and after this.
+		int x64GenContext::GetFirstParamRegIndex()
+		{
+			const IntPassInfo &retInfo = m_Proto.GetRet();
+			int reg_index = 0;
+			if (retInfo.size != 0 && (retInfo.flags & PassInfo::PassFlag_RetMem) == PassInfo::PassFlag_RetMem)
+				++reg_index;
+			return reg_index + 1;
+		}
+
+		// Which integer argument register param p arrives in, following the System V
+		// classification: floats take an SSE register instead, an aggregate of at most
+		// two eightbytes takes one integer register per eightbyte, and a larger one is
+		// passed in memory.  A result at or past the register count means the caller
+		// put it on the stack.  Passing the param count gives the slot just after the
+		// declared params, which is where a vafmt format string sits.
+		int x64GenContext::GetIntRegForParam(int p)
+		{
+			int reg_index = GetFirstParamRegIndex();
+			for (int i = 0; i < p; ++i)
+			{
+				const IntPassInfo &pi = m_Proto.GetParam(i);
+
+				// Only a float passed by value goes to the SSE file: a reference to one
+				// is a pointer like any other.
+				if (pi.type == PassInfo::PassType_Float &&
+					(pi.flags & PassInfo::PassFlag_ByRef) == 0)
+					continue;
+
+				if (pi.type == PassInfo::PassType_Object &&
+					(pi.flags & PassInfo::PassFlag_ByVal) &&
+					(pi.flags & PassFlag_ForcedByRef) == 0)
+				{
+					if (pi.size <= 16)
+						reg_index += (static_cast<int>(pi.size) + 7) / 8;
+					continue;
+				}
+
+				++reg_index;
+			}
+			return reg_index;
+		}
+
+		int x64GenContext::GetNumFloatParams()
+		{
+			int count = 0;
+			for (int i = 0; i < m_Proto.GetNumOfParams(); ++i)
+			{
+				const IntPassInfo &pi = m_Proto.GetParam(i);
+				if (pi.type == PassInfo::PassType_Float &&
+					(pi.flags & PassInfo::PassFlag_ByRef) == 0)
+					++count;
+			}
+			return count;
+		}
+
+		// How many bytes of the caller's stack the declared params took, so that a
+		// va_list can be pointed past them at the varargs.
+		std::int32_t x64GenContext::GetNamedArgsStackSize()
+		{
+			const int num_reg = 6;
+			const int num_floatreg = 8;
+			int reg_index = GetFirstParamRegIndex();
+			int floatreg_index = 0;
+			std::int32_t bytes = 0;
+
+			for (int i = 0; i < m_Proto.GetNumOfParams(); ++i)
+			{
+				const IntPassInfo &pi = m_Proto.GetParam(i);
+
+				if (pi.type == PassInfo::PassType_Float &&
+					(pi.flags & PassInfo::PassFlag_ByRef) == 0)
+				{
+					if (floatreg_index < num_floatreg)
+						++floatreg_index;
+					else
+						bytes += 8;
+				}
+				else if (pi.type == PassInfo::PassType_Object &&
+					(pi.flags & PassInfo::PassFlag_ByVal) &&
+					(pi.flags & PassFlag_ForcedByRef) == 0)
+				{
+					int eightbytes = (static_cast<int>(pi.size) + 7) / 8;
+					if (pi.size <= 16 && reg_index + eightbytes <= num_reg)
+						reg_index += eightbytes;
+					else
+						bytes += AlignSize(static_cast<std::int32_t>(pi.size), 8);
+				}
+				else if (reg_index < num_reg)
+				{
+					++reg_index;
+				}
+				else
+				{
+					bytes += 8;
+				}
+			}
+			return bytes;
 		}
 
 		void* x64GenContext::GeneratePubFunc()

--- a/core/sourcehook/sourcehook_hookmangen_x86_64.cpp
+++ b/core/sourcehook/sourcehook_hookmangen_x86_64.cpp
@@ -495,6 +495,17 @@ namespace SourceHook
 
 			// vafmt: the formatted string, plus the register save area and the cursor
 			// over it that a va_list is on this ABI.
+			// An aggregate returned in registers can be SSE or INTEGER class, and a
+			// PassInfo does not say which. Keeping the registers the original left
+			// behind lets the value be handed back untouched when no hook replaced
+			// it, whichever class it really is.
+			v_raw_ret = 0;
+			if (retInfo.size != 0 && retInfo.type == PassInfo::PassType_Object &&
+				(retInfo.flags & PassInfo::PassFlag_RetReg) && retInfo.size != 12)
+			{
+				v_raw_ret = AddVarToFrame(32);
+			}
+
 			v_va_buf = 0;
 			v_va_regsave = 0;
 			v_va_list = 0;
@@ -638,7 +649,7 @@ namespace SourceHook
 
 			// Hand the return value back before the three objects below are destroyed:
 			// the one being returned is one of them.
-			DoReturn(v_ret_ptr, v_memret_ptr);
+			DoReturn(v_ret_ptr, v_memret_ptr, v_status);
 
 			// If return value type has a destructor, call it
 			if ((retInfo.flags & PassInfo::PassFlag_ByVal) && retInfo.pDtor != nullptr)
@@ -1022,6 +1033,16 @@ namespace SourceHook
 				// epilog free the stack
 				m_HookFunc.add(rsp, stackSpace);
 			}
+
+#if SH_COMP == SH_COMP_GCC
+			if (v_raw_ret)
+			{
+				m_HookFunc.mov(rbp(v_raw_ret + 0), rax);
+				m_HookFunc.mov(rbp(v_raw_ret + 8), rdx);
+				m_HookFunc.movsd(rbp(v_raw_ret + 16), xmm0);
+				m_HookFunc.movsd(rbp(v_raw_ret + 24), xmm1);
+			}
+#endif
 
 			SaveReturnValue(v_place_for_memret, v_orig_ret);
 
@@ -1498,7 +1519,7 @@ namespace SourceHook
 			m_HookFunc.mov(rbp(v_retptr), rax);
 		}
 
-		void x64GenContext::DoReturn(int v_retptr, int v_memret_outaddr)
+		void x64GenContext::DoReturn(int v_retptr, int v_memret_outaddr, int v_status)
 		{
 			const auto& retInfo = m_Proto.GetRet();
 			if (retInfo.size == 0) {
@@ -1527,12 +1548,39 @@ namespace SourceHook
 			if (retInfo.type == PassInfo::PassType_Float) {
 				m_HookFunc.movsd(xmm0, r8());
 			}
-			else if (retInfo.type == PassInfo::PassType_Basic || 
-				((retInfo.type == PassInfo::PassType_Object) && (retInfo.flags & PassInfo::PassFlag_RetReg)) ) {
-				m_HookFunc.mov(rax, r8());
-				if (retInfo.type == PassInfo::PassType_Object && retInfo.size > 8) {
-					m_HookFunc.mov(rdx, r8(8));
+			else if (retInfo.type == PassInfo::PassType_Object && (retInfo.flags & PassInfo::PassFlag_RetReg)) {
+#if SH_COMP == SH_COMP_GCC
+				if (v_raw_ret) {
+					// Which registers hold an aggregate depends on the class of each
+					// of its eightbytes, and a PassInfo does not carry field types, so
+					// SourceHook's copy of the value is read as INTEGER. Both files are
+					// loaded so that the caller finds the value wherever its own
+					// classification says to look: the integer ones follow that copy,
+					// including a hook's replacement for it, while the SSE ones carry
+					// through what the original returned. An SSE class aggregate
+					// therefore comes back intact, but a hook cannot replace it.
+					m_HookFunc.lea(r9, rbp(v_raw_ret));
+					m_HookFunc.mov(rax, rbp(v_status));
+					m_HookFunc.cmp(rax, MRES_OVERRIDE);
+					m_HookFunc.cmovge(r9, r8);
+
+					m_HookFunc.mov(rax, r9());
+					m_HookFunc.movsd(xmm0, rbp(v_raw_ret + 16));
+					if (retInfo.size > 8) {
+						m_HookFunc.mov(rdx, r9(8));
+						m_HookFunc.movsd(xmm1, rbp(v_raw_ret + 24));
+					}
+				} else
+#endif
+				{
+					m_HookFunc.mov(rax, r8());
+					if (retInfo.size > 8) {
+						m_HookFunc.mov(rdx, r8(8));
+					}
 				}
+			}
+			else if (retInfo.type == PassInfo::PassType_Basic) {
+				m_HookFunc.mov(rax, r8());
 			}
 
 			if (retInfo.flags & PassInfo::PassFlag_RetMem)

--- a/core/sourcehook/sourcehook_hookmangen_x86_64.cpp
+++ b/core/sourcehook/sourcehook_hookmangen_x86_64.cpp
@@ -127,6 +127,10 @@ namespace SourceHook
 			delete m_pHI;
 			delete m_HookfuncVfnptr;
 			delete m_BuiltPI;
+			// Not Clear(): that would also drop the generated code, which outlives
+			// this object. These two do not.
+			delete [] m_BuiltPI_Params;
+			delete [] m_BuiltPI_Params2;
 		}
 
 		void x64GenContext::Clear()
@@ -159,10 +163,10 @@ namespace SourceHook
 			m_BuiltPI->retPassInfo2.pAssignOperator = m_Proto.GetRet().pAssignOperator;
 
 			if (m_BuiltPI_Params)
-				delete m_BuiltPI_Params;
+				delete [] m_BuiltPI_Params;
 			m_BuiltPI_Params = new PassInfo[m_BuiltPI->numOfParams + 1];
 			if (m_BuiltPI_Params2)
-				delete m_BuiltPI_Params2;
+				delete [] m_BuiltPI_Params2;
 			m_BuiltPI_Params2 = new PassInfo::V2Info[m_BuiltPI->numOfParams + 1];
 
 			m_BuiltPI_Params[0].size = 1;			// Version 1

--- a/core/sourcehook/sourcehook_hookmangen_x86_64.h
+++ b/core/sourcehook/sourcehook_hookmangen_x86_64.h
@@ -83,6 +83,12 @@ namespace SourceHook
 
 			std::int32_t m_HookFunc_FrameOffset;
 			std::int32_t m_HookFunc_FrameVarsSize;
+
+#if SH_COMP == SH_COMP_GCC
+			// Placed here temporarily so I don't have to pass it around in function calls...
+			std::int32_t v_sysv_floatreg;
+			std::int32_t v_sysv_reg;
+#endif
 		};
 	}
 }

--- a/core/sourcehook/sourcehook_hookmangen_x86_64.h
+++ b/core/sourcehook/sourcehook_hookmangen_x86_64.h
@@ -38,12 +38,12 @@ namespace SourceHook
 
 			std::int32_t AddVarToFrame(std::int32_t size);
 			std::int32_t ComputeVarsSize();
-			std::int32_t x64GenContext::GetRealSize(const IntPassInfo& info);
+			std::int32_t GetRealSize(const IntPassInfo& info);
 			std::int32_t AlignSize(std::int32_t x, std::int32_t boundary);
 			std::int32_t GetParamStackSize(const IntPassInfo &info);
 
 			void Clear();
-			void AutoDetectRetType();
+			bool AutoDetectRetType();
 			void AutoDetectParamFlags();
 			bool PassInfoSupported(const IntPassInfo& pi, bool is_ret);
 			void BuildProtoInfo();

--- a/core/sourcehook/sourcehook_hookmangen_x86_64.h
+++ b/core/sourcehook/sourcehook_hookmangen_x86_64.h
@@ -22,7 +22,6 @@ namespace SourceHook
 		class x64GenContext : public IGenContext
 		{
 		public:
-			x64GenContext();
 			x64GenContext(const ProtoInfo *proto, int vtbl_offs, int vtbl_idx, ISourceHook *pSHPtr);
 			virtual ~x64GenContext();
 
@@ -35,6 +34,12 @@ namespace SourceHook
 			friend void foo_test();
 
 			static const std::int32_t SIZE_PTR = sizeof(void*);
+
+			// ByVal in the proto, but System V hands the callee a pointer to the
+			// caller's object instead of a copy -> the hook func has to make its own
+			// copy and destroy it again.  Same idea, and same value, as the x86
+			// generator's flag of this name.
+			static const int PassFlag_ForcedByRef = (1<<30);
 
 			std::int32_t AddVarToFrame(std::int32_t size);
 			std::int32_t ComputeVarsSize();
@@ -60,7 +65,14 @@ namespace SourceHook
 			void CallEndContext(int v_pContext);
 			void DoReturn(int v_retptr, int v_memret_outaddr);
 
-			std::int32_t PushParameters(int v_this, int v_ret);
+			std::int32_t PushParameters(int v_this, int v_ret, bool orig_call);
+			void DestroyParams();
+			std::int32_t GetForcedByRefParamOffset(int p);
+			std::int32_t GetForcedByRefParamsSize();
+			int GetFirstParamRegIndex();
+			int GetIntRegForParam(int p);
+			std::int32_t GetNamedArgsStackSize();
+			int GetNumFloatParams();
 			void SaveReturnValue(int v_mem_ret, int v_ret);
 
 			HookManagerPubFunc m_GeneratedPubFunc;
@@ -88,6 +100,10 @@ namespace SourceHook
 			// Placed here temporarily so I don't have to pass it around in function calls...
 			std::int32_t v_sysv_floatreg;
 			std::int32_t v_sysv_reg;
+			std::int32_t v_fbrr_base;
+			std::int32_t v_va_buf;
+			std::int32_t v_va_regsave;
+			std::int32_t v_va_list;
 #endif
 		};
 	}

--- a/core/sourcehook/sourcehook_hookmangen_x86_64.h
+++ b/core/sourcehook/sourcehook_hookmangen_x86_64.h
@@ -63,7 +63,7 @@ namespace SourceHook
 			void GenerateCallOrig(int v_status, int v_pContext, int v_this, int v_vfnptr_origentry, int v_orig_ret, int v_override_ret, int v_place_for_memret);
 			void PrepareReturn(int v_status, int v_pContext, int v_retptr);
 			void CallEndContext(int v_pContext);
-			void DoReturn(int v_retptr, int v_memret_outaddr);
+			void DoReturn(int v_retptr, int v_memret_outaddr, int v_status);
 
 			std::int32_t PushParameters(int v_this, int v_ret, bool orig_call);
 			void DestroyParams();
@@ -104,6 +104,7 @@ namespace SourceHook
 			std::int32_t v_va_buf;
 			std::int32_t v_va_regsave;
 			std::int32_t v_va_list;
+			std::int32_t v_raw_ret;
 #endif
 		};
 	}

--- a/core/sourcehook/test/AMBuilder
+++ b/core/sourcehook/test/AMBuilder
@@ -4,9 +4,6 @@ import os
 for cxx in MMS.all_targets:
   name = 'test_sourcehook'
   binary = MMS.Program(cxx, name)
-  if binary.compiler.target.arch == 'x86_64' and binary.compiler.target.platform == 'linux':
-    continue
-
   binary.compiler.defines += [
     'SOURCEHOOK_TESTS',
   ]
@@ -48,5 +45,8 @@ for cxx in MMS.all_targets:
     binary.sources += ['../sourcehook_hookmangen_x86.cpp']
   elif binary.compiler.target.arch == 'x86_64':
     binary.sources += ['../sourcehook_hookmangen_x86_64.cpp']
+    # sourcehook_hookmangen.cpp picks its generator on this; without it the test
+    # would build the x86 one and fail to link.
+    binary.compiler.defines += ['PLATFORM_64BITS']
 
   builder.Add(binary)

--- a/core/sourcehook/test/main.cpp
+++ b/core/sourcehook/test/main.cpp
@@ -78,7 +78,7 @@ int main(int argc, char *argv[])
 	DO_TEST(RefRet);
 	DO_TEST(VPHooks);
 	DO_TEST(CPageAlloc);
-#if !defined( _M_AMD64 ) && !defined( __amd64__ ) && !defined(__x86_64__)	// TODO: Fix for 64-bit
+#if !defined( _M_AMD64 )	// TODO: the Windows x64 generator is still untested
 	DO_TEST(HookManGen);
 #endif
 	DO_TEST(OddThunks);
@@ -128,7 +128,7 @@ void Test_UnpausePlugin(SourceHook::ISourceHook *shptr, SourceHook::Plugin plug)
 	static_cast<SourceHook::Impl::CSourceHookImpl *>(shptr)->UnpausePlugin(plug);
 }
 
-#if !defined( _M_AMD64 ) && !defined( __amd64__ ) && !defined(__x86_64__)
+#if !defined( _M_AMD64 )
 SourceHook::IHookManagerAutoGen *Test_HMAG_Factory(SourceHook::ISourceHook *shptr)
 {
 	return new SourceHook::Impl::CHookManagerAutoGen(shptr);

--- a/core/sourcehook/test/testhookmangen.cpp
+++ b/core/sourcehook/test/testhookmangen.cpp
@@ -598,6 +598,64 @@ namespace
 		}
 	};
 
+
+	// A return value made only of floats comes back in the SSE registers. A
+	// PassInfo carries sizes but not field types, so the generator cannot tell
+	// that apart from an aggregate of integers, and reads SourceHook's copy of
+	// the value as INTEGER. What it can do, and has to, is carry the registers
+	// the original returned in through untouched. Replacing such a value from a
+	// hook is not covered below because it does not work: the copy a hook writes
+	// is read back as INTEGER as well.
+	struct FloatPair
+	{
+		float a;
+		float b;
+	};
+
+	MAKE_STATE_1(State_FloatPair_Called, int);
+	MAKE_STATE_1(State_FloatPair_PreHook, int);
+
+	class FloatPairTest
+	{
+	public:
+		virtual FloatPair Get(int seed)
+		{
+			ADD_STATE(State_FloatPair_Called(seed));
+			FloatPair ret;
+			ret.a = seed + 0.5f;
+			ret.b = seed + 1.5f;
+			return ret;
+		}
+	};
+
+	MAKE_STATE_1(State_FloatPair_PostHook, int);
+
+	// A post hook that returns a value of the same type leaves it in the SSE
+	// registers, which is what the original's return value has to survive.
+	class FloatPair_PostDeleg : public MyDelegate
+	{
+		virtual FloatPair Call(int seed)
+		{
+			ADD_STATE(State_FloatPair_PostHook(seed));
+			FloatPair scratch;
+			scratch.a = seed * 3.25f;
+			scratch.b = seed * 7.75f;
+			RETURN_META_VALUE(MRES_IGNORED, scratch);
+		}
+	};
+
+	class FloatPair_Deleg : public MyDelegate
+	{
+		virtual FloatPair Call(int seed)
+		{
+			ADD_STATE(State_FloatPair_PreHook(seed));
+			FloatPair unused;
+			unused.a = 0.0f;
+			unused.b = 0.0f;
+			RETURN_META_VALUE(MRES_IGNORED, unused);
+		}
+	};
+
 	bool Tests1(std::string &error)
 	{
 		THGM_DO_TEST_void(0, ());
@@ -1092,6 +1150,60 @@ namespace
 
 		return true;
 	}
+
+	bool Tests6(std::string &error)
+	{
+		FloatPairTest *pFloatPair = new FloatPairTest;
+		CAutoPtrDestruction<FloatPairTest> apdFloatPair(pFloatPair);
+
+		SourceHook::CProtoInfoBuilder floatPairPi(SourceHook::ProtoInfo::CallConv_ThisCall);
+		floatPairPi.AddParam(sizeof(int), SourceHook::PassInfo::PassType_Basic,
+			SourceHook::PassInfo::PassFlag_ByVal, NULL, NULL, NULL, NULL);
+		floatPairPi.SetReturnType(sizeof(FloatPair), SourceHook::PassInfo::PassType_Object,
+			SourceHook::PassInfo::PassFlag_ByVal, NULL, NULL, NULL, NULL);
+
+		// FloatPairTest::Get is the only virtual it has.
+		SourceHook::HookManagerPubFunc floatPairHM = g_HMAGPtr->MakeHookMan(floatPairPi, 0, 0);
+		CHECK_COND(floatPairHM != NULL, "TestFloatPairRet /makehookman");
+		CAutoReleaseHookMan arhm_floatPair(floatPairHM);
+
+		FloatPair unhooked = pFloatPair->Get(10);
+		CHECK_STATES((&g_States,
+			new State_FloatPair_Called(10),
+			NULL), "TestFloatPairRet Part1");
+
+		int floatPairHook = g_SHPtr->AddHook(g_PLID, SourceHook::ISourceHook::Hook_Normal,
+			reinterpret_cast<void*>(pFloatPair), 0, floatPairHM, new FloatPair_Deleg, false);
+
+		FloatPair preHooked = pFloatPair->Get(10);
+		CHECK_STATES((&g_States,
+			new State_FloatPair_PreHook(10),
+			new State_FloatPair_Called(10),
+			NULL), "TestFloatPairRet Part2");
+
+		int floatPairPost = g_SHPtr->AddHook(g_PLID, SourceHook::ISourceHook::Hook_Normal,
+			reinterpret_cast<void*>(pFloatPair), 0, floatPairHM, new FloatPair_PostDeleg, true);
+
+		FloatPair bothHooked = pFloatPair->Get(10);
+		CHECK_STATES((&g_States,
+			new State_FloatPair_PreHook(10),
+			new State_FloatPair_Called(10),
+			new State_FloatPair_PostHook(10),
+			NULL), "TestFloatPairRet Part3");
+
+		// The hooks come off before the values are judged: a CHECK that returns
+		// early would leave them installed, and SourceHook shutting down after the
+		// generator has gone takes the process with it.
+		g_SHPtr->RemoveHookByID(floatPairPost);
+		g_SHPtr->RemoveHookByID(floatPairHook);
+
+		CHECK_COND(unhooked.a == 10.5f && unhooked.b == 11.5f, "TestFloatPairRet Part1 /value");
+		CHECK_COND(preHooked.a == 10.5f && preHooked.b == 11.5f, "TestFloatPairRet Part2 /value");
+		CHECK_COND(bothHooked.a == 10.5f && bothHooked.b == 11.5f, "TestFloatPairRet Part3 /value");
+
+		return true;
+	}
+
 }
 
 #if !defined( _M_AMD64 )
@@ -1119,6 +1231,8 @@ bool TestHookManGen(std::string &error)
 	if (!Tests4(error))
 		return false;
 	if (!Tests5(error))
+		return false;
+	if (!Tests6(error))
 		return false;
 
 	// Shutdown now!

--- a/core/sourcehook/test/testhookmangen.cpp
+++ b/core/sourcehook/test/testhookmangen.cpp
@@ -1094,7 +1094,7 @@ namespace
 	}
 }
 
-#if !defined( _M_AMD64 ) && !defined( __amd64__ ) && !defined(__x86_64__)
+#if !defined( _M_AMD64 )
 bool TestHookManGen(std::string &error)
 {
 	GET_SHPTR(g_SHPtr);


### PR DESCRIPTION
`core/AMBuilder` leaves `sourcehook_hookmangen_x86_64.cpp` out of the build on Linux, and the file would not compile there anyway: `sh_asm_x86_64.h` names a method `xor`, which outside of MSVC is an alternative token for `^`. So on 64 bit Linux Metamod:Source ships with no hook manager generator at all, and anything that builds hook managers at runtime cannot work on a CS2 server there.

This is @rtldg's branch from #212, rebased onto current master with his commits intact, plus fixes for what still kept the generated code from working. He closed that PR himself. The work was close, and this is the rest of it.

## What was wrong

Each of these was found by a failing case in the existing `TestHookManGen`, which is turned off for 64 bit with a `// TODO: Fix for 64-bit`.

* `GenerateHookFunc` opened with a leftover `breakpoint()`. That one is only on the branch, not on master.
* `PushParameters` ignored `v_this` on System V and restored the incoming argument registers instead, so a hook delegate ran with the hooked object as its `this`. It read a foreign object for its own fields and returned whatever that produced as its `META_RES` — in the test suite that came out as `MRES_SUPERCEDE`, so the original never ran. The MSVC path already did this correctly.
* An object passed by value with a destructor or a copy constructor arrives by invisible reference, so every hook and the original shared the caller's object. They each get a copy now, destroyed after the call it was made for, which is what the x86 generator has always done. The end-of-function parameter destruction becomes MSVC only, since under the Itanium ABI the caller destroys arguments.
* The three internal return objects were destroyed before `DoReturn` copied one of them out.
* Returning an object by value was refused outright unless it was exactly 12 bytes, and the threshold for returning in memory was 64 bytes rather than two eightbytes.
* `CallConv_HasVafmt` was accepted but nothing was ever formatted, so hooks were handed the raw format string. A `va_list` is now built over a register save area laid out the way the ABI describes, and `vsnprintf` runs once before any hook sees anything.
* A reference to a float takes an integer register, not an SSE one.
* `x64GenContext` leaked its two `PassInfo` arrays — `Clear()` is commented out in the destructor and nothing else released them — and both generators released those arrays with `delete` rather than `delete[]`. The second half of that applies to x86 as well, so it affects builds that ship today.
* Which registers hold an aggregate returned by value depends on the class of each of its eightbytes, and a `PassInfo` carries sizes but not field types. Nothing was written to the SSE registers on the way out, so a post hook returning a value of the same type left its own in `xmm0` and the caller got that instead of the function's. Both register files are loaded now: the integer ones follow SourceHook's copy of the value, the SSE ones carry the original's through.

Protos that would need an argument register the ABI does not have are declined rather than generated wrongly.

## Checks

| | |
|---|---|
| clang 18.1, x86_64, `--enable-optimize` | 16/16 |
| gcc 13.3, x86_64 | 16/16 |
| clang 18.1, x86 | 16/16 |
| valgrind, `--smc-check=all-non-file --leak-check=full` | no errors, nothing left leaking from the generator |
| metamod for CS2, x86_64 Linux | builds and links |

`TestHookManGen` is around forty protos: empty ones and ones with five parameters, floats and doubles, PODs of 7 and 600 bytes by value and by reference, objects with constructors, destructors and assignment operators, returns of char, short, int, float, double and PODs of 1, 4, 8 and 13 bytes, objects with a destructor in the return, vafmt in every combination, high vtable indices — and for each of them the full matrix of pre and post hooks with ignore, supercede, override and recall, checking the exact sequence of constructor and destructor calls.

Building and running it again for 64 bit Linux needed one more thing: the generator's dependency on metamod is only there for a debug helper whose calls are commented out, so it moves under `#if !defined(SOURCEHOOK_TESTS)`. The CI already runs `test_sourcehook` for `linux-x86_64` when that directory exists, so this starts being covered without any change there.

Stack alignment was checked rather than argued about. Every generated function was dumped, disassembled and walked over its control flow graph, tracking `rsp` through pushes, pops and adjustments: 74 functions, 414 `call` instructions, every one of them with `rsp` 16 byte aligned and every `ret` with the alignment the ABI asks for. That covers the two boxes left unticked in the review on #212, `GeneratePubFunc` and `CallSetupHookLoop` — the second had already been dealt with on the branch.

Beyond the suite, this ran on a CS2 dedicated server with a plugin that takes metamod's own `IHookManagerAutoGen` and hooks through generated code: pre and post hooks on `GameFrame` reading a field through `this`, an object passed by value where the hook scribbles over its copy and the original still sees clean data, a vafmt function where the hook is handed the formatted string, an aggregate of two floats returned through a post hook, and a thousand `MakeHookMan` and `ReleaseHookMan` cycles repeated three times — the first run grows the page pool, the two after it move nothing.

## Known limits

* Windows x64 is untested here. Everything but the return value handling and the two `delete[]` fixes is under `#if SH_COMP == SH_COMP_GCC`, and the test stays off for MSVC.
* A hook cannot replace an aggregate return value of the SSE class. That was already true, only silently; it is at least predictable now. Doing better needs field types in `ProtoInfo`, which seemed like your call rather than something to slip in here.
* Aggregates of 9 to 16 bytes that mix integer and SSE eightbytes have the same problem.
