### PR TITLE
Filter empty entries out of the SDK list

### DIFF
--- a/AMBuildScript
+++ b/AMBuildScript
@@ -87,7 +87,7 @@ class MMSConfig(object):
     return True
 
   def detectSDKs(self):
-    sdk_list = builder.options.sdks.split(',')
+    sdk_list = [s for s in builder.options.sdks.split(',') if s]
     SdkHelpers.sdk_filter = self.shouldIncludeSdk
     SdkHelpers.find_sdk_path = self.findSdkPath
     SdkHelpers.findSdks(builder, self.all_targets, sdk_list)


### PR DESCRIPTION
`--sdks=` splits into a list holding one empty string rather than an empty list, and that empty string is then looked up as an SDK name. It never matches anything, so configure fails with `Error: hl2sdk- was not found.` and `Missing hl2sdks:` — both without a name, which makes the cause hard to see.

The `pr-checks` workflow passes `--sdks=` for the two SourceHook test builds, so those steps cannot configure at all on this branch. `master` already filters empty entries here; this is the same line.

Checked on a clean `1.12-dev` checkout: before, `python3 ../configure.py --enable-optimize --enable-tests --sdks=` fails as above; after, it configures, builds, and the SourceHook suite passes 16 of 16 on linux-x86.

Ordinary builds are unaffected — `--sdks=hl2dm` produces the same artifacts before and after, and the only differences between the two binaries are the build path and the compile timestamp, which also differ between two runs of the unmodified code.
